### PR TITLE
Feature/llm system instruction

### DIFF
--- a/src/modules/experiment/dto/experiment-tasks-execution.dto.ts
+++ b/src/modules/experiment/dto/experiment-tasks-execution.dto.ts
@@ -13,6 +13,12 @@ export class ExperimentTaskExecutionDto {
   @ApiProperty()
   taskTitle: string;
 
+  @ApiProperty()
+  taskType: string;
+
+  @ApiProperty({ nullable: true, required: false })
+  systemInstruction?: string | null;
+
   @ApiProperty({ type: [TaskExecutionDetailsDto] })
   executions: TaskExecutionDetailsDto[];
 }

--- a/src/modules/experiment/experiment.service.spec.ts
+++ b/src/modules/experiment/experiment.service.spec.ts
@@ -3,20 +3,24 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import type { TestingModule } from '@nestjs/testing';
-import { Test } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import type {TestingModule} from '@nestjs/testing';
+import {Test} from '@nestjs/testing';
+import {getRepositoryToken} from '@nestjs/typeorm';
 
-import { IcfService } from '../icf/icf.service';
-import { SurveyType } from '../survey/entity/survey.entity';
-import { SurveyService } from '../survey/survey.service';
-import { TaskService } from '../task/task.service';
-import { UserService } from '../user/user.service';
-import { UserExperimentService } from '../user-experiment/user-experiment.service';
-import { UserTaskService } from '../user-task/user-task.service';
-import type { CreateExperimentDto } from './dto/create-experiment.dto';
-import { Experiment, ExperimentStatus,StepsType } from './entity/experiment.entity';
-import { ExperimentService } from './experiment.service';
+import {IcfService} from '../icf/icf.service';
+import {SurveyType} from '../survey/entity/survey.entity';
+import {SurveyService} from '../survey/survey.service';
+import {TaskService} from '../task/task.service';
+import {UserService} from '../user/user.service';
+import {UserExperimentService} from '../user-experiment/user-experiment.service';
+import {UserTaskService} from '../user-task/user-task.service';
+import type {CreateExperimentDto} from './dto/create-experiment.dto';
+import {
+  Experiment,
+  ExperimentStatus,
+  StepsType,
+} from './entity/experiment.entity';
+import {ExperimentService} from './experiment.service';
 
 describe('ExperimentService', () => {
   let service: ExperimentService;
@@ -24,10 +28,17 @@ describe('ExperimentService', () => {
     find: jest.Mock;
     findOneBy: jest.Mock;
     findOne: jest.Mock;
+    createQueryBuilder: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
     update: jest.Mock;
     delete: jest.Mock;
+  };
+  let mockExperimentQueryBuilder: {
+    leftJoinAndSelect: jest.Mock;
+    addSelect: jest.Mock;
+    where: jest.Mock;
+    getOne: jest.Mock;
   };
   let mockUserExperimentService: {
     getDetailedStats: jest.Mock;
@@ -58,11 +69,21 @@ describe('ExperimentService', () => {
       find: jest.fn(),
       findOneBy: jest.fn(),
       findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
     };
+    mockExperimentQueryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    };
+    mockExperimentRepository.createQueryBuilder.mockReturnValue(
+      mockExperimentQueryBuilder,
+    );
 
     mockUserExperimentService = {
       getDetailedStats: jest.fn(),
@@ -164,18 +185,18 @@ describe('ExperimentService', () => {
         ],
         typeExperiment: 'within-subject',
         betweenExperimentType: null,
-        icf: { title: 'ICF Title', description: 'ICF Description' },
+        icf: {title: 'ICF Title', description: 'ICF Description'},
       };
 
-      const mockUser = { _id: 'owner-1', name: 'Owner' };
-      const savedExperiment = { _id: 'exp-1', ...createExperimentDto };
+      const mockUser = {_id: 'owner-1', name: 'Owner'};
+      const savedExperiment = {_id: 'exp-1', ...createExperimentDto};
 
       mockUserService.findOne.mockResolvedValue(mockUser);
       mockExperimentRepository.create.mockReturnValue(savedExperiment);
       mockExperimentRepository.save.mockResolvedValue(savedExperiment);
-      mockSurveyService.create.mockResolvedValue({ _id: 'survey-1' });
-      mockTaskService.create.mockResolvedValue({ _id: 'task-1' });
-      mockIcfService.create.mockResolvedValue({ _id: 'icf-1' });
+      mockSurveyService.create.mockResolvedValue({_id: 'survey-1'});
+      mockTaskService.create.mockResolvedValue({_id: 'task-1'});
+      mockIcfService.create.mockResolvedValue({_id: 'icf-1'});
 
       const result = await service.create(createExperimentDto);
 
@@ -191,8 +212,8 @@ describe('ExperimentService', () => {
   describe('findAll', () => {
     it('should return all experiments', async () => {
       const experiments = [
-        { _id: 'exp-1', name: 'Experiment 1' },
-        { _id: 'exp-2', name: 'Experiment 2' },
+        {_id: 'exp-1', name: 'Experiment 1'},
+        {_id: 'exp-2', name: 'Experiment 2'},
       ];
 
       mockExperimentRepository.find.mockResolvedValue(experiments);
@@ -206,7 +227,7 @@ describe('ExperimentService', () => {
 
   describe('find', () => {
     it('should find an experiment by id', async () => {
-      const experiment = { _id: 'exp-1', name: 'Experiment 1' };
+      const experiment = {_id: 'exp-1', name: 'Experiment 1'};
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
 
       const result = await service.find('exp-1');
@@ -220,7 +241,7 @@ describe('ExperimentService', () => {
 
   describe('getStats', () => {
     it('should return experiment stats', async () => {
-      const stats = { totalParticipants: 10, completedTasks: 8 };
+      const stats = {totalParticipants: 10, completedTasks: 8};
       mockUserExperimentService.getDetailedStats.mockResolvedValue(stats);
 
       const result = await service.getStats('exp-1');
@@ -235,8 +256,8 @@ describe('ExperimentService', () => {
   describe('getParticipants', () => {
     it('should return experiment participants', async () => {
       const participants = [
-        { userId: 'user-1', status: 'completed' },
-        { userId: 'user-2', status: 'pending' },
+        {userId: 'user-1', status: 'completed'},
+        {userId: 'user-2', status: 'pending'},
       ];
       mockUserExperimentService.getParticipantsDetails.mockResolvedValue(
         participants,
@@ -256,14 +277,14 @@ describe('ExperimentService', () => {
       const experiment = {
         _id: 'exp-1',
         name: 'Experiment 1',
-        tasks: [{ _id: 'task-1', title: 'Task 1' }],
+        tasks: [{_id: 'task-1', title: 'Task 1'}],
       };
       mockExperimentRepository.findOne.mockResolvedValue(experiment);
 
       const result = await service.findWithTasks('exp-1');
 
       expect(mockExperimentRepository.findOne).toHaveBeenCalledWith({
-        where: { _id: 'exp-1' },
+        where: {_id: 'exp-1'},
         relations: ['tasks'],
       });
       expect(result).toEqual(experiment);
@@ -273,14 +294,14 @@ describe('ExperimentService', () => {
   describe('getTasksExecutionDetails', () => {
     it('should return tasks execution details grouped by task', async () => {
       const userTasks = [
-        { task_id: 'task-1', task: { title: 'Task 1' }, execution: 'data-1' },
-        { task_id: 'task-1', task: { title: 'Task 1' }, execution: 'data-2' },
+        {task_id: 'task-1', task: {title: 'Task 1'}, execution: 'data-1'},
+        {task_id: 'task-1', task: {title: 'Task 1'}, execution: 'data-2'},
       ];
 
       mockUserTaskService.findByExperimentId.mockResolvedValue(userTasks);
       mockUserTaskService.getExecutionDetailsFromEntity
-        .mockResolvedValueOnce({ details: 'execution-1' })
-        .mockResolvedValueOnce({ details: 'execution-2' });
+        .mockResolvedValueOnce({details: 'execution-1'})
+        .mockResolvedValueOnce({details: 'execution-2'});
 
       const result = await service.getTasksExecutionDetails('exp-1');
 
@@ -296,14 +317,14 @@ describe('ExperimentService', () => {
   describe('getSurveysStats', () => {
     it('should return surveys statistics', async () => {
       const surveys = [
-        { _id: 'survey-1', title: 'Survey 1' },
-        { _id: 'survey-2', title: 'Survey 2' },
+        {_id: 'survey-1', title: 'Survey 1'},
+        {_id: 'survey-2', title: 'Survey 2'},
       ];
 
       mockSurveyService.findByExperimentId.mockResolvedValue(surveys);
       mockSurveyService.getStats
-        .mockResolvedValueOnce({ responses: 10 })
-        .mockResolvedValueOnce({ responses: 8 });
+        .mockResolvedValueOnce({responses: 10})
+        .mockResolvedValueOnce({responses: 8});
 
       const result = await service.getSurveysStats('exp-1');
 
@@ -316,16 +337,19 @@ describe('ExperimentService', () => {
 
   describe('update', () => {
     it('should update an experiment', async () => {
-      const updateDto = { name: 'Updated Experiment', status: ExperimentStatus.IN_PROGRESS };
-      const updatedExperiment = { _id: 'exp-1', ...updateDto };
+      const updateDto = {
+        name: 'Updated Experiment',
+        status: ExperimentStatus.IN_PROGRESS,
+      };
+      const updatedExperiment = {_id: 'exp-1', ...updateDto};
 
-      mockExperimentRepository.update.mockResolvedValue({ affected: 1 });
+      mockExperimentRepository.update.mockResolvedValue({affected: 1});
       mockExperimentRepository.findOneBy.mockResolvedValue(updatedExperiment);
 
       const result = await service.update('exp-1', updateDto);
 
       expect(mockExperimentRepository.update).toHaveBeenCalledWith(
-        { _id: 'exp-1' },
+        {_id: 'exp-1'},
         updateDto,
       );
       expect(result).toEqual(updatedExperiment);
@@ -334,9 +358,9 @@ describe('ExperimentService', () => {
 
   describe('remove', () => {
     it('should remove an experiment', async () => {
-      const experiment = { _id: 'exp-1', name: 'Experiment 1' };
+      const experiment = {_id: 'exp-1', name: 'Experiment 1'};
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
-      mockExperimentRepository.delete.mockResolvedValue({ affected: 1 });
+      mockExperimentRepository.delete.mockResolvedValue({affected: 1});
 
       const result = await service.remove('exp-1');
 
@@ -351,11 +375,11 @@ describe('ExperimentService', () => {
     it('should build experiment steps correctly', async () => {
       const experiment = {
         _id: 'exp-1',
-        icfs: [{ _id: 'icf-1' }],
-        tasks: [{ _id: 'task-1' }],
+        icfs: [{_id: 'icf-1'}],
+        tasks: [{_id: 'task-1'}],
         surveys: [
-          { _id: 'survey-1', type: SurveyType.PRE },
-          { _id: 'survey-2', type: SurveyType.POST },
+          {_id: 'survey-1', type: SurveyType.PRE},
+          {_id: 'survey-2', type: SurveyType.POST},
         ],
       };
 
@@ -378,7 +402,7 @@ describe('ExperimentService', () => {
         summary: 'Test Summary',
         typeExperiment: 'within-subject',
         betweenExperimentType: null,
-        icfs: [{ title: 'ICF Title', description: 'ICF Description' }],
+        icfs: [{title: 'ICF Title', description: 'ICF Description'}],
         surveys: [
           {
             name: 'Survey 1',
@@ -398,22 +422,33 @@ describe('ExperimentService', () => {
             rule_type: 'score',
             max_score: 100,
             min_score: 0,
-            search_source: 'search-engine',
+            search_source: 'llm',
+            provider_config: {
+              modelProvider: 'google',
+              model: 'gemini-2.5-flash',
+              systemInstruction: 'Answer as a research assistant.',
+              apiKey: 'secret-api-key',
+            },
             survey_id: 'survey-1',
           },
         ],
       };
 
-      mockExperimentRepository.findOne.mockResolvedValue(experiment);
+      mockExperimentQueryBuilder.getOne.mockResolvedValue(experiment);
 
       const result = await service.exportToYaml('exp-1');
 
       expect(typeof result).toBe('string');
       expect(result).toContain('Test Experiment');
+      expect(result).toContain(
+        'systemInstruction: Answer as a research assistant.',
+      );
+      expect(result).toContain('search_model: gemini-2.5-flash');
+      expect(result).not.toContain('secret-api-key');
     });
 
     it('should throw error if experiment not found', async () => {
-      mockExperimentRepository.findOne.mockResolvedValue(null);
+      mockExperimentQueryBuilder.getOne.mockResolvedValue(null);
 
       await expect(service.exportToYaml('exp-1')).rejects.toThrow(
         'Experiment not found',
@@ -447,14 +482,16 @@ describe('ExperimentService', () => {
             - title: Task 1
               summary: Task Summary
               description: Task Description
-              search_source: search-engine
+              search_source: llm
+              search_model: gemini-2.5-flash
+              systemInstruction: Answer as a research assistant.
               rule_type: score
               min_score: 0
               max_score: 100
       `;
 
-      const mockUser = { _id: 'owner-1' };
-      const savedExperiment = { _id: 'exp-1', name: 'Test Import' };
+      const mockUser = {_id: 'owner-1'};
+      const savedExperiment = {_id: 'exp-1', name: 'Test Import'};
 
       mockUserService.findOne.mockResolvedValue(mockUser);
       mockExperimentRepository.create.mockReturnValue(savedExperiment);
@@ -467,6 +504,15 @@ describe('ExperimentService', () => {
 
       expect(result).toEqual([]);
       expect(mockExperimentRepository.save).toHaveBeenCalled();
+      expect(mockTaskService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_config: expect.objectContaining({
+            modelProvider: 'google',
+            model: 'gemini-2.5-flash',
+            systemInstruction: 'Answer as a research assistant.',
+          }),
+        }),
+      );
     });
 
     it('should return validation errors for invalid YAML', async () => {
@@ -484,8 +530,8 @@ describe('ExperimentService', () => {
 
   describe('getGeneralExpirementInfos', () => {
     it('should return general experiment information', async () => {
-      const experiment = { _id: 'exp-1', status: 'active' };
-      const userInfos = { total: 10, completed: 8 };
+      const experiment = {_id: 'exp-1', status: 'active'};
+      const userInfos = {total: 10, completed: 8};
 
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
       mockUserExperimentService.countUsersByExperimentId.mockResolvedValue(
@@ -501,7 +547,7 @@ describe('ExperimentService', () => {
 
   describe('findOneByName', () => {
     it('should find experiment by name', async () => {
-      const experiment = { _id: 'exp-1', name: 'Test Experiment' };
+      const experiment = {_id: 'exp-1', name: 'Test Experiment'};
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
 
       const result = await service.findOneByName('Test Experiment');
@@ -515,13 +561,13 @@ describe('ExperimentService', () => {
 
   describe('findByOwnerId', () => {
     it('should find experiments by owner id', async () => {
-      const experiments = [{ _id: 'exp-1', owner_id: 'owner-1' }];
+      const experiments = [{_id: 'exp-1', owner_id: 'owner-1'}];
       mockExperimentRepository.find.mockResolvedValue(experiments);
 
       const result = await service.findByOwnerId('owner-1');
 
       expect(mockExperimentRepository.find).toHaveBeenCalledWith({
-        where: { owner_id: 'owner-1' },
+        where: {owner_id: 'owner-1'},
       });
       expect(result).toEqual(experiments);
     });

--- a/src/modules/experiment/experiment.service.ts
+++ b/src/modules/experiment/experiment.service.ts
@@ -221,6 +221,11 @@ export class ExperimentService {
       result.push({
         taskId: taskId,
         taskTitle: data.task.title,
+        taskType: data.task.search_source,
+        systemInstruction:
+          data.task.search_source === 'llm'
+            ? data.task.provider_config?.systemInstruction ?? null
+            : null,
         executions: executionsDetails,
       });
     }

--- a/src/modules/experiment/experiment.service.ts
+++ b/src/modules/experiment/experiment.service.ts
@@ -9,14 +9,14 @@ import * as yaml from 'js-yaml';
 import {Repository} from 'typeorm';
 
 import {IcfService} from '../icf/icf.service';
-import { QuestionDTO, QuestionType } from '../survey/dto/question.dto';
-import { SurveyType } from '../survey/entity/survey.entity';
+import {QuestionDTO, QuestionType} from '../survey/dto/question.dto';
+import {SurveyType} from '../survey/entity/survey.entity';
 import {SurveyService} from '../survey/survey.service';
-import { Task } from '../task/entities/task.entity';
+import {Task, TaskProviderConfig} from '../task/entities/task.entity';
 import {TaskService} from '../task/task.service';
 import {UserService} from '../user/user.service';
 import {UserExperimentService} from '../user-experiment/user-experiment.service';
-import { UserTask } from '../user-task/entities/user-tasks.entity';
+import {UserTask} from '../user-task/entities/user-tasks.entity';
 import {UserTaskService} from '../user-task/user-task.service';
 import {CreateExperimentDto} from './dto/create-experiment.dto';
 import {ExperimentParticipantDto} from './dto/experiment-participant.dto';
@@ -61,6 +61,9 @@ type YamlTask = {
   max_score?: number;
   min_score?: number;
   search_source?: string;
+  search_model?: string;
+  systemInstruction?: string;
+  provider_config?: TaskProviderConfig;
   survey_id?: string | null;
 };
 
@@ -224,7 +227,7 @@ export class ExperimentService {
         taskType: data.task.search_source,
         systemInstruction:
           data.task.search_source === 'llm'
-            ? data.task.provider_config?.systemInstruction ?? null
+            ? (data.task.provider_config?.systemInstruction ?? null)
             : null,
         executions: executionsDetails,
       });
@@ -259,9 +262,9 @@ export class ExperimentService {
     id: string,
     updateExperimentDto: UpdateExperimentDto,
   ): Promise<Experiment> {
-      await this.experimentRepository.update({_id: id}, updateExperimentDto);
-      const result = await this.find(id);
-      return result;
+    await this.experimentRepository.update({_id: id}, updateExperimentDto);
+    const result = await this.find(id);
+    return result;
   }
 
   async remove(id: string) {
@@ -312,10 +315,14 @@ export class ExperimentService {
   }
 
   async exportToYaml(id: string): Promise<string> {
-    const experiment = await this.experimentRepository.findOne({
-      where: {_id: id},
-      relations: ['tasks', 'surveys', 'icfs'],
-    });
+    const experiment = await this.experimentRepository
+      .createQueryBuilder('experiment')
+      .leftJoinAndSelect('experiment.tasks', 'task')
+      .addSelect('task.provider_config')
+      .leftJoinAndSelect('experiment.surveys', 'survey')
+      .leftJoinAndSelect('experiment.icfs', 'icf')
+      .where('experiment._id = :id', {id})
+      .getOne();
 
     if (!experiment) {
       throw new Error('Experiment not found');
@@ -347,20 +354,93 @@ export class ExperimentService {
             required: survey.required,
           })) || [],
         tasks:
-          experiment.tasks?.map((task) => ({
-            title: task.title,
-            summary: task.summary,
-            description: task.description,
-            rule_type: task.rule_type,
-            max_score: task.max_score,
-            min_score: task.min_score,
-            search_source: task.search_source,
-            survey_id: task.survey_id,
-          })) || [],
+          experiment.tasks?.map((task) => {
+            const providerConfig = this.buildYamlProviderConfig(task);
+            const yamlTask: YamlTask = {
+              title: task.title,
+              summary: task.summary,
+              description: task.description,
+              rule_type: task.rule_type,
+              max_score: task.max_score,
+              min_score: task.min_score,
+              search_source: task.search_source,
+              survey_id: task.survey_id,
+            };
+
+            const searchModel =
+              providerConfig?.model || providerConfig?.searchProvider;
+            if (searchModel) {
+              yamlTask.search_model = searchModel;
+            }
+            if (providerConfig?.systemInstruction) {
+              yamlTask.systemInstruction = providerConfig.systemInstruction;
+            }
+            if (providerConfig) {
+              yamlTask.provider_config = providerConfig;
+            }
+
+            return yamlTask;
+          }) || [],
       },
     };
 
     return yaml.dump(yamlData);
+  }
+
+  private buildYamlProviderConfig(task: Task): TaskProviderConfig | undefined {
+    const providerConfig = task.provider_config || {};
+    const yamlProviderConfig: TaskProviderConfig = {};
+
+    if (task.search_source === 'llm') {
+      if (providerConfig.modelProvider) {
+        yamlProviderConfig.modelProvider = providerConfig.modelProvider;
+      }
+      if (providerConfig.model) {
+        yamlProviderConfig.model = providerConfig.model;
+      }
+      if (providerConfig.systemInstruction) {
+        yamlProviderConfig.systemInstruction = providerConfig.systemInstruction;
+      }
+    }
+
+    if (
+      task.search_source === 'search-engine' &&
+      providerConfig.searchProvider
+    ) {
+      yamlProviderConfig.searchProvider = providerConfig.searchProvider;
+    }
+
+    return Object.keys(yamlProviderConfig).length > 0
+      ? yamlProviderConfig
+      : undefined;
+  }
+
+  private buildProviderConfigFromYaml(
+    task: YamlTask,
+  ): TaskProviderConfig | undefined {
+    const providerConfig: TaskProviderConfig = {
+      ...(task.provider_config || {}),
+    };
+
+    if (task.search_source === 'llm') {
+      providerConfig.modelProvider = providerConfig.modelProvider || 'google';
+      if (task.search_model && !providerConfig.model) {
+        providerConfig.model = task.search_model;
+      }
+      if (task.systemInstruction && !providerConfig.systemInstruction) {
+        providerConfig.systemInstruction = task.systemInstruction;
+      }
+    }
+
+    if (
+      task.search_source === 'search-engine' &&
+      task.search_model &&
+      !providerConfig.searchProvider
+    ) {
+      providerConfig.searchProvider = task.search_model;
+    }
+
+    return Object.keys(providerConfig).length > 0 ? providerConfig : undefined;
   }
 
   async importFromYaml(
@@ -446,6 +526,7 @@ export class ExperimentService {
             max_score: task.max_score || 0,
             questionsId: [],
             experiment_id: savedExperiment._id,
+            provider_config: this.buildProviderConfigFromYaml(task),
           });
         });
         await Promise.all(tasksPromises);
@@ -456,7 +537,7 @@ export class ExperimentService {
       console.error('Error importing YAML:', error);
       throw new Error(
         `Failed to import experiment: ${error instanceof Error ? error.message : 'unknown error'}`,
-        { cause: error },
+        {cause: error},
       );
     }
   }

--- a/src/modules/llm-session/entity/llm-session.entity.ts
+++ b/src/modules/llm-session/entity/llm-session.entity.ts
@@ -6,6 +6,7 @@
 import { Task } from 'src/modules/task/entities/task.entity';
 import { User } from 'src/modules/user/entity/user.entity';
 import {
+  Column,
   Entity,
   ManyToOne,
   OneToMany,
@@ -24,6 +25,9 @@ export class LlmSession {
 
   @ManyToOne(() => Task, (task) => task.llmSessions, { onDelete: 'CASCADE' })
   task: Task;
+
+  @Column({ nullable: true, type: 'text' })
+  systemInstruction?: string | null;
 
   @OneToMany(() => LlmMessage, (msg) => msg.session, { cascade: true })
   messages: LlmMessage[];

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -63,6 +63,7 @@ export class LlmSessionService {
             apiKey: true,
             modelProvider: true,
             model: true,
+            systemPrompt: true,
           },
         },
       },
@@ -98,7 +99,17 @@ export class LlmSessionService {
 
     const modelName = providerConfig.model || 'gemini-2.5-flash';
     const genAI = new GoogleGenerativeAI(providerConfig.apiKey);
-    const model = genAI.getGenerativeModel({ model: modelName });
+    const modelConfig: any = {
+      model: modelName,
+    };
+
+    if (providerConfig.systemInstruction) {
+      modelConfig.systemInstruction = {
+        parts: [{ text: providerConfig.systemInstruction }],
+      };
+    }
+
+    const model = genAI.getGenerativeModel(modelConfig);
     const chat = model.startChat({ history: historyForAi });
 
     try {

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -17,6 +17,11 @@ import { Repository } from 'typeorm';
 import { LlmMessage } from './entity/llm-message.entity';
 import { LlmSession } from './entity/llm-session.entity';
 
+type GoogleModelConfig = {
+  model: string;
+  systemInstruction?: string;
+};
+
 @Injectable()
 export class LlmSessionService {
   constructor(
@@ -38,7 +43,11 @@ export class LlmSessionService {
       return existingSession;
     }
 
-    const task = await this.taskRepository.findOne({ where: { _id: taskId } });
+    const task = await this.taskRepository
+      .createQueryBuilder('task')
+      .addSelect('task.provider_config')
+      .where('task._id = :taskId', { taskId })
+      .getOne();
     if (!task) {
       throw new NotFoundException('Task not found');
     }
@@ -46,28 +55,20 @@ export class LlmSessionService {
     const newSession = this.llmSessionRepository.create({
       user: { _id: userId } as User,
       task: task,
+      systemInstruction: task.provider_config?.systemInstruction ?? null,
     });
 
     return await this.llmSessionRepository.save(newSession);
   }
 
   async processChatMessage(sessionId: string, userId: string, content: string) {
-    const session = await this.llmSessionRepository.findOne({
-      where: { id: sessionId },
-      relations: ['task', 'user'],
-      select: {
-        id: true,
-        task: {
-          _id: true,
-          provider_config: {
-            apiKey: true,
-            modelProvider: true,
-            model: true,
-            systemPrompt: true,
-          },
-        },
-      },
-    });
+    const session = await this.llmSessionRepository
+      .createQueryBuilder('session')
+      .leftJoinAndSelect('session.task', 'task')
+      .leftJoinAndSelect('session.user', 'user')
+      .addSelect('task.provider_config')
+      .where('session.id = :sessionId', { sessionId })
+      .getOne();
     if (!session) throw new NotFoundException('Session not found');
     if (session.user._id !== userId)
       throw new ForbiddenException('Session does not belong to user');
@@ -99,14 +100,12 @@ export class LlmSessionService {
 
     const modelName = providerConfig.model || 'gemini-2.5-flash';
     const genAI = new GoogleGenerativeAI(providerConfig.apiKey);
-    const modelConfig: any = {
+    const modelConfig: GoogleModelConfig = {
       model: modelName,
     };
 
     if (providerConfig.systemInstruction) {
-      modelConfig.systemInstruction = {
-        parts: [{ text: providerConfig.systemInstruction }],
-      };
+      modelConfig.systemInstruction = providerConfig.systemInstruction;
     }
 
     const model = genAI.getGenerativeModel(modelConfig);

--- a/src/modules/task/dto/task-response.dto.ts
+++ b/src/modules/task/dto/task-response.dto.ts
@@ -36,7 +36,7 @@ export class TaskResponseDto {
   @ApiProperty({ description: 'Maximum score to qualify', example: 25, required: false })
   max_score?: number;
 
-  @ApiProperty({ description: 'Provider configuration returned by API', example: {"model":"gemini-2.5-flash","apiKey":"asda-----sdsadd","modelProvider":"google"}, required: false })
+  @ApiProperty({ description: 'Provider configuration returned by API', example: {"model":"gemini-2.5-flash","apiKey":"asda-----sdsadd","modelProvider":"google","systemInstruction":"You are a friendly and helpful assistant."}, required: false })
   provider_config?: Record<string, unknown>;
 
   @ApiProperty({ description: 'Whether secret fields in provider config were masked', example: true, required: false })

--- a/src/modules/task/entities/task.entity.ts
+++ b/src/modules/task/entities/task.entity.ts
@@ -18,6 +18,7 @@ export type TaskProviderConfig = {
   model?: string;
   apiKey?: string;
   cx?: string;
+  systemInstruction?: string;
   [key: string]: unknown;
 };
 

--- a/src/modules/user-task/dto/task-execution-details.dto.ts
+++ b/src/modules/user-task/dto/task-execution-details.dto.ts
@@ -59,6 +59,8 @@ export class LlmMessageDetailsDto {
 }
 
 export class LlmTaskDetailsDto {
+  @ApiProperty({ nullable: true, required: false, description: 'System instruction configured for the LLM task' })
+  systemInstruction?: string | null;
 
   @ApiProperty({ type: [LlmMessageDetailsDto], description: 'Messages exchanged with the model' })
   messages: LlmMessageDetailsDto[];

--- a/src/modules/user-task/user-task.service.ts
+++ b/src/modules/user-task/user-task.service.ts
@@ -8,7 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { LlmSessionService } from 'src/modules/llm-session/llm-session.service';
 import { In, Repository } from 'typeorm';
 
-import { Task } from '../task/entities/task.entity';
+import { Task, type TaskProviderConfig } from '../task/entities/task.entity';
 import { TaskService } from '../task/task.service';
 import { TaskQuestionMapService } from '../task-question-map/task-question-map.service';
 import { User } from '../user/entity/user.entity';
@@ -384,11 +384,26 @@ export class UserTaskService {
     return tasks.length;
   }
 
+  private getSystemInstruction(
+    sessionSystemInstruction: string | null | undefined,
+    task: Task,
+  ): string | null {
+    return (
+      sessionSystemInstruction ??
+      (task.provider_config as TaskProviderConfig | undefined)
+        ?.systemInstruction ??
+      null
+    );
+  }
+
   async getExecutionDetails(userTaskId: string): Promise<TaskExecutionDetailsDto> {
-    const userTask = await this.userTaskRepository.findOne({
-      where: { _id: userTaskId },
-      relations: ['task', 'user']
-    });
+    const userTask = await this.userTaskRepository
+      .createQueryBuilder('userTask')
+      .leftJoinAndSelect('userTask.task', 'task')
+      .leftJoinAndSelect('userTask.user', 'user')
+      .addSelect('task.provider_config')
+      .where('userTask._id = :userTaskId', { userTaskId })
+      .getOne();
 
     if (!userTask) {
       throw new NotFoundException('UserTask not found');
@@ -457,6 +472,10 @@ export class UserTaskService {
 
       const messages = llmSession ? llmSession.messages : [];
       details.llmDetails = {
+        systemInstruction: this.getSystemInstruction(
+          llmSession?.systemInstruction,
+          task,
+        ),
         messages: messages.map(m => ({
           content: m.content,
           role: m.role,
@@ -471,14 +490,13 @@ export class UserTaskService {
   }
 
   async findByExperimentId(experimentId: string): Promise<UserTask[]> {
-    return await this.userTaskRepository.find({
-      relations: ['task', 'user'],
-      where: {
-        task: {
-          experiment_id: experimentId
-        }
-      }
-    });
+    return await this.userTaskRepository
+      .createQueryBuilder('userTask')
+      .leftJoinAndSelect('userTask.task', 'task')
+      .leftJoinAndSelect('userTask.user', 'user')
+      .addSelect('task.provider_config')
+      .where('task.experiment_id = :experimentId', { experimentId })
+      .getMany();
   }
 
   async getExecutionDetailsFromEntity(userTask: UserTask): Promise<TaskExecutionDetailsDto> {
@@ -545,6 +563,10 @@ export class UserTaskService {
 
       const messages = llmSession ? llmSession.messages : [];
       details.llmDetails = {
+        systemInstruction: this.getSystemInstruction(
+          llmSession?.systemInstruction,
+          task,
+        ),
         messages: messages.map(m => ({
           content: m.content,
           role: m.role,
@@ -559,12 +581,13 @@ export class UserTaskService {
   }
 
   async findByUserAndTask(userId: string, taskId: string): Promise<UserTask[]> {
-    return await this.userTaskRepository.find({
-      relations: ['task', 'user'],
-      where: {
-        user: { _id: userId },
-        task: { _id: taskId }
-      }
-    });
+    return await this.userTaskRepository
+      .createQueryBuilder('userTask')
+      .leftJoinAndSelect('userTask.task', 'task')
+      .leftJoinAndSelect('userTask.user', 'user')
+      .addSelect('task.provider_config')
+      .where('user._id = :userId', { userId })
+      .andWhere('task._id = :taskId', { taskId })
+      .getMany();
   }
 }


### PR DESCRIPTION
This PR updates the backend to accept and persist the `systemInstruction` field in the provider configuration for chat tasks.

The field is now handled when creating and editing tasks, and it is also returned as part of the task configuration response.

chat task creation now accepts `systemInstruction`
chat task editing preserves and updates `systemInstruction`
task configuration responses now include `systemInstruction`