### PR TITLE
feat: implement task-survey linking, LLM provider registry and   system instruction support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git
 .gitignore
+.env
+.env.*
 node_modules/
 dist/
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.24.1",
+    "@langchain/core": "^1.1.40",
+    "@langchain/openai": "^1.4.4",
     "@nestjs-modules/mailer": "^1.11.2",
     "@nestjs/common": "^11.1.16",
     "@nestjs/config": "^4.0.3",
@@ -64,6 +65,7 @@
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
+    "@types/validator": "^13.15.10",
     "axios": "^1.13.6",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.2",
     "swagger-ui-express": "^5.0.1",
-    "typeorm": "^0.3.28"
+    "typeorm": "^0.3.28",
+    "axios": "^1.13.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -66,7 +67,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
     "@types/validator": "^13.15.10",
-    "axios": "^1.13.6",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     dependencies:
-      '@google/generative-ai':
-        specifier: ^0.24.1
-        version: 0.24.1
+      '@langchain/core':
+        specifier: ^1.1.40
+        version: 1.1.40(openai@6.34.0(zod@4.3.6))
+      '@langchain/openai':
+        specifier: ^1.4.4
+        version: 1.4.4(@langchain/core@1.1.40(openai@6.34.0(zod@4.3.6)))
       '@nestjs-modules/mailer':
         specifier: ^1.11.2
         version: 1.11.2(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(nodemailer@6.10.1)
@@ -120,6 +123,9 @@ importers:
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
+      '@types/validator':
+        specifier: ^13.15.10
+        version: 13.15.10
       axios:
         specifier: ^1.13.6
         version: 1.13.6
@@ -362,6 +368,9 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -393,28 +402,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@css-inline/css-inline-linux-arm64-musl@0.13.0':
     resolution: {integrity: sha512-V5h5+CRnE01EgoafI/kyjEcM8zvN+sKLnp17Aq9LqQfsut7mO3i72d8g/xeVC37DCLoGQFLvDCzbze2NbF2dIQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@css-inline/css-inline-linux-x64-gnu@0.13.0':
     resolution: {integrity: sha512-vbRV++73MW7dvz/AIbozkv4R68/k/sEp57hno/L6lx034VYxpCwdfqtGN4D0W1TOTzdr2b6qBOGNZ1oLKQZOQQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@css-inline/css-inline-linux-x64-musl@0.13.0':
     resolution: {integrity: sha512-2tCnwU23W/yMs9cGc2/i2jd9y2pjuntx0a5OytqX7s9fvUtmI3nc0Od6wuf51LnmdU+XAU8HLT9pZppsQiwPfQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@css-inline/css-inline-win32-x64-msvc@0.13.0':
     resolution: {integrity: sha512-6VFhFSXp4FH+NzJhLd6fFi7jKCPvIRW+vq0tV+CPuiQ3zPzMfC9nIk8sB/1VJR8EcvBAjMV53YnacuDjRFRT9g==}
@@ -464,10 +469,6 @@ packages:
   '@eslint/plugin-kit@0.6.1':
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@google/generative-ai@0.24.1':
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -747,6 +748,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@langchain/core@1.1.40':
+    resolution: {integrity: sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==}
+    engines: {node: '>=20'}
+
+  '@langchain/openai@1.4.4':
+    resolution: {integrity: sha512-mRr/X5rvlwPj6cSXPxbL+CtOqYANO1/+CQ3Z+5t48kWnrlgPYOazmA+UAWvqQOuwJ6LaYn3SFrt43rR4lte/Ow==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.39
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -1680,6 +1691,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -1974,6 +1989,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -2581,6 +2599,9 @@ packages:
   js-stringify@1.0.2:
     resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
 
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2647,6 +2668,26 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  langsmith@0.5.21:
+    resolution: {integrity: sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+      ws: '>=7'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+      ws:
+        optional: true
 
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
@@ -2951,6 +2992,10 @@ packages:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3047,6 +3092,18 @@ packages:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
     engines: {node: '>=8'}
 
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3078,6 +3135,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -3918,6 +3979,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -4060,6 +4125,9 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -4310,6 +4378,8 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@cfworker/json-schema@4.1.1': {}
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -4385,8 +4455,6 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.1
       levn: 0.4.1
-
-  '@google/generative-ai@0.24.1': {}
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -4764,6 +4832,35 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@langchain/core@1.1.40(openai@6.34.0(zod@4.3.6))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.5.21(openai@6.34.0(zod@4.3.6))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      uuid: 11.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/openai@1.4.4(@langchain/core@1.1.40(openai@6.34.0(zod@4.3.6)))':
+    dependencies:
+      '@langchain/core': 1.1.40(openai@6.34.0(zod@4.3.6))
+      js-tiktoken: 1.0.21
+      openai: 6.34.0(zod@4.3.6)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - ws
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -5850,6 +5947,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   dedent@1.7.2: {}
 
   deep-extend@0.6.0: {}
@@ -6111,6 +6210,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  eventemitter3@4.0.7: {}
 
   events@3.3.0: {}
 
@@ -7019,6 +7120,10 @@ snapshots:
 
   js-stringify@1.0.2: {}
 
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -7096,6 +7201,13 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  langsmith@0.5.21(openai@6.34.0(zod@4.3.6)):
+    dependencies:
+      p-queue: 6.6.2
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 6.34.0(zod@4.3.6)
 
   leac@0.6.0: {}
 
@@ -7569,6 +7681,8 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
+  mustache@4.2.0: {}
+
   mute-stream@2.0.0: {}
 
   natural-compare@1.4.0: {}
@@ -7642,6 +7756,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openai@6.34.0(zod@4.3.6):
+    optionalDependencies:
+      zod: 4.3.6
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -7684,6 +7802,11 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
 
   p-timeout@3.2.0:
     dependencies:
@@ -8500,6 +8623,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@10.0.0: {}
+
   uuid@11.1.0: {}
 
   uuid@9.0.1: {}
@@ -8664,3 +8789,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zod@4.3.6: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@types/passport-local':
         specifier: ^1.0.38
         version: 1.0.38
+      axios:
+        specifier: ^1.13.6
+        version: 1.13.6
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -126,9 +129,6 @@ importers:
       '@types/validator':
         specifier: ^13.15.10
         version: 13.15.10
-      axios:
-        specifier: ^1.13.6
-        version: 1.13.6
       eslint:
         specifier: ^10.0.3
         version: 10.0.3

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,8 @@ import {Task} from './modules/task/entities/task.entity';
 import {TaskModule} from './modules/task/task.module';
 import {TaskQuestionMap} from './modules/task-question-map/entity/taskQuestionMap.entity';
 import {TaskQuestionMapModule} from './modules/task-question-map/task-question-map.module';
+import {TaskSurvey} from './modules/task-survey/entity/taskSurvey.entity';
+import {TaskSurveyModule} from './modules/task-survey/task-survey.module';
 import {User} from './modules/user/entity/user.entity';
 import {UserModule} from './modules/user/user.module';
 import {UserExperiment} from './modules/user-experiment/entities/user-experiments.entity';
@@ -73,6 +75,7 @@ import {UserTaskSessionModule} from './modules/user-task-session/user-task-sessi
           UserTask,
           SurveyAnswer,
           TaskQuestionMap,
+          TaskSurvey,
           Icf,
           UserTaskSession,
           Page,
@@ -98,6 +101,7 @@ import {UserTaskSessionModule} from './modules/user-task-session/user-task-sessi
     SurveyModule,
     SurveyAnswerModule,
     TaskQuestionMapModule,
+    TaskSurveyModule,
     IcfModule,
     UserTaskSessionModule,
     LlmSessionModule,

--- a/src/modules/experiment/dto/create-experiment.dto.ts
+++ b/src/modules/experiment/dto/create-experiment.dto.ts
@@ -3,11 +3,95 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {ApiProperty} from '@nestjs/swagger';
+import {Type} from 'class-transformer';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { CreateSurveyDto } from 'src/modules/survey/dto/create-survey.dto';
 
-import { TaskProps } from '../entity/experiment.entity';
+export class CreateExperimentTaskPropsDto {
+  @ApiProperty({description: 'Temporary task reference', required: false})
+  @IsOptional()
+  @IsString()
+  uuid?: string;
+
+  @ApiProperty({description: 'Task title', example: 'Task 1'})
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({description: 'Task summary', example: 'Task summary'})
+  @IsNotEmpty()
+  @IsString()
+  summary: string;
+
+  @ApiProperty({description: 'Task description', required: false})
+  @IsOptional()
+  @IsString()
+  description: string;
+
+  @ApiProperty({description: 'Task search source', example: 'search-engine'})
+  @IsNotEmpty()
+  @IsString()
+  search_source: string;
+
+  @ApiProperty({description: 'Legacy single linked survey id/ref', required: false})
+  @IsOptional()
+  @IsString()
+  SelectedSurvey?: string;
+
+  @ApiProperty({description: 'Rules experiment type', required: false})
+  @IsOptional()
+  @IsString()
+  RulesExperiment?: string;
+
+  @ApiProperty({description: 'Minimum score threshold', required: false})
+  @IsOptional()
+  ScoreThreshold?: number;
+
+  @ApiProperty({description: 'Maximum score threshold', required: false})
+  @IsOptional()
+  ScoreThresholdmx?: number;
+
+  @ApiProperty({description: 'Question ids linked to this task', required: false})
+  @IsOptional()
+  @IsArray()
+  @IsString({each: true})
+  selectedQuestionIds?: string[];
+
+  @ApiProperty({description: 'Provider config for llm/search', required: false})
+  @IsOptional()
+  @IsObject()
+  provider_config?: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Optional list of survey references (temporary uuid or real id) to link in task_survey',
+    required: false,
+    example: ['survey-temp-1', 'survey-temp-2'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({each: true})
+  linkedSurveyRefs?: string[];
+}
+
+export class CreateExperimentIcfDto {
+  @ApiProperty({description: 'ICF title', example: 'Consent'})
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({description: 'ICF description', example: 'You agree to participate.'})
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+}
 
 export class CreateExperimentDto {
   @ApiProperty({ description: 'Experiment name', example: 'Bias Study A' })
@@ -37,21 +121,48 @@ export class CreateExperimentDto {
 
   @ApiProperty({
     description: 'Task definitions used in the experiment',
-    type: 'array',
-    items: { type: 'object' },
+    type: [CreateExperimentTaskPropsDto],
+    example: [
+      {
+        uuid: 'task-temp-1',
+        title: 'Task 1',
+        summary: 'Task summary',
+        description: 'Task description',
+        search_source: 'search-engine',
+        linkedSurveyRefs: ['survey-temp-1'],
+      },
+    ],
   })
-  tasksProps: TaskProps[];
+  @IsArray()
+  @ValidateNested({each: true})
+  @Type(() => CreateExperimentTaskPropsDto)
+  tasksProps: CreateExperimentTaskPropsDto[];
   @ApiProperty({
     description: 'Survey definitions used in the experiment',
     type: [CreateSurveyDto],
+    example: [
+      {
+        uuid: 'survey-temp-1',
+        name: 'survey-name',
+        title: 'Survey title',
+        description: 'Survey description',
+        type: 'pre',
+        questions: [],
+        uniqueAnswer: false,
+      },
+    ],
   })
+  @IsArray()
+  @ValidateNested({each: true})
+  @Type(() => CreateSurveyDto)
   surveysProps: CreateSurveyDto[];
 
   @ApiProperty({
     description: 'ICF (consent) information',
     example: { title: 'Consent', description: 'You agree to participate.' },
+    type: CreateExperimentIcfDto,
   })
-  icf: { title: string; description: string };
-
-
+  @ValidateNested()
+  @Type(() => CreateExperimentIcfDto)
+  icf: CreateExperimentIcfDto;
 }

--- a/src/modules/experiment/dto/create-experiment.dto.ts
+++ b/src/modules/experiment/dto/create-experiment.dto.ts
@@ -7,13 +7,16 @@ import {ApiProperty} from '@nestjs/swagger';
 import {Type} from 'class-transformer';
 import {
   IsArray,
+  IsBoolean,
+  IsEnum,
   IsNotEmpty,
   IsObject,
   IsOptional,
   IsString,
   ValidateNested,
 } from 'class-validator';
-import { CreateSurveyDto } from 'src/modules/survey/dto/create-survey.dto';
+import {QuestionDTO} from 'src/modules/survey/dto/question.dto';
+import {SurveyType} from 'src/modules/survey/entity/survey.entity';
 
 export class CreateExperimentTaskPropsDto {
   @ApiProperty({description: 'Temporary task reference', required: false})
@@ -93,6 +96,51 @@ export class CreateExperimentIcfDto {
   description: string;
 }
 
+export class CreateExperimentSurveyPropsDto {
+  @ApiProperty({description: 'Temporary survey reference', required: false})
+  @IsOptional()
+  @IsString()
+  uuid?: string;
+
+  @ApiProperty({description: 'Internal survey name', example: 'survey-name'})
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({description: 'Survey title', example: 'Survey title'})
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({description: 'Survey description', example: 'Survey description'})
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+
+  @ApiProperty({enum: SurveyType, description: 'Survey type'})
+  @IsEnum(SurveyType)
+  type: SurveyType;
+
+  @ApiProperty({type: [QuestionDTO], description: 'Survey questions'})
+  @IsArray()
+  @ValidateNested({each: true})
+  @Type(() => QuestionDTO)
+  questions: QuestionDTO[];
+
+  @ApiProperty({description: 'Whether survey answers must be unique', example: false})
+  @IsNotEmpty()
+  @IsBoolean()
+  uniqueAnswer: boolean;
+
+  @ApiProperty({
+    description: 'Deprecated on POST /experiment and ignored when provided',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  experimentId?: string;
+}
+
 export class CreateExperimentDto {
   @ApiProperty({ description: 'Experiment name', example: 'Bias Study A' })
   @IsNotEmpty()
@@ -139,7 +187,7 @@ export class CreateExperimentDto {
   tasksProps: CreateExperimentTaskPropsDto[];
   @ApiProperty({
     description: 'Survey definitions used in the experiment',
-    type: [CreateSurveyDto],
+    type: [CreateExperimentSurveyPropsDto],
     example: [
       {
         uuid: 'survey-temp-1',
@@ -154,8 +202,8 @@ export class CreateExperimentDto {
   })
   @IsArray()
   @ValidateNested({each: true})
-  @Type(() => CreateSurveyDto)
-  surveysProps: CreateSurveyDto[];
+  @Type(() => CreateExperimentSurveyPropsDto)
+  surveysProps: CreateExperimentSurveyPropsDto[];
 
   @ApiProperty({
     description: 'ICF (consent) information',

--- a/src/modules/experiment/dto/experiment-tasks-execution.dto.ts
+++ b/src/modules/experiment/dto/experiment-tasks-execution.dto.ts
@@ -13,6 +13,12 @@ export class ExperimentTaskExecutionDto {
   @ApiProperty()
   taskTitle: string;
 
+  @ApiProperty()
+  taskType: string;
+
+  @ApiProperty({ nullable: true, required: false })
+  systemInstruction?: string | null;
+
   @ApiProperty({ type: [TaskExecutionDetailsDto] })
   executions: TaskExecutionDetailsDto[];
 }

--- a/src/modules/experiment/experiment.service.spec.ts
+++ b/src/modules/experiment/experiment.service.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
+import {BadRequestException} from '@nestjs/common';
 import type {TestingModule} from '@nestjs/testing';
 import {Test} from '@nestjs/testing';
 import {getRepositoryToken} from '@nestjs/typeorm';
@@ -33,6 +34,9 @@ describe('ExperimentService', () => {
     save: jest.Mock;
     update: jest.Mock;
     delete: jest.Mock;
+    manager: {
+      transaction: jest.Mock;
+    };
   };
   let mockExperimentQueryBuilder: {
     leftJoinAndSelect: jest.Mock;
@@ -63,6 +67,19 @@ describe('ExperimentService', () => {
   let mockIcfService: {
     create: jest.Mock;
   };
+  let mockTransactionManager: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let mockTaskSurveyInsertBuilder: {
+    insert: jest.Mock;
+    into: jest.Mock;
+    values: jest.Mock;
+    orIgnore: jest.Mock;
+    execute: jest.Mock;
+  };
 
   beforeEach(async () => {
     mockExperimentRepository = {
@@ -74,7 +91,29 @@ describe('ExperimentService', () => {
       save: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
+      manager: {
+        transaction: jest.fn(),
+      },
     };
+
+    mockTaskSurveyInsertBuilder = {
+      insert: jest.fn().mockReturnThis(),
+      into: jest.fn().mockReturnThis(),
+      values: jest.fn().mockReturnThis(),
+      orIgnore: jest.fn().mockReturnThis(),
+      execute: jest.fn(),
+    };
+
+    mockTransactionManager = {
+      create: jest.fn((_, entity) => entity),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(() => mockTaskSurveyInsertBuilder),
+    };
+
+    mockExperimentRepository.manager.transaction.mockImplementation(
+      async (callback) => callback(mockTransactionManager),
+    );
     mockExperimentQueryBuilder = {
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
@@ -152,7 +191,75 @@ describe('ExperimentService', () => {
   });
 
   describe('create', () => {
-    it('should create an experiment with surveys, tasks, and icf', async () => {
+    it('should create an experiment with surveys, tasks, linked task-survey rows, and icf', async () => {
+      const createExperimentDto: CreateExperimentDto = {
+        name: 'Test Experiment',
+        ownerId: 'owner-1',
+        summary: 'Test Summary',
+        tasksProps: [
+          {
+            uuid: 'task-temp-1',
+            title: 'Task 1',
+            summary: 'Task Summary',
+            description: 'Task Description',
+            search_source: 'search-engine',
+            SelectedSurvey: 'survey-1',
+            RulesExperiment: 'score',
+            ScoreThreshold: 0,
+            ScoreThresholdmx: 100,
+            selectedQuestionIds: [],
+            provider_config: {},
+            linkedSurveyRefs: ['survey-1', 'survey-1'],
+          },
+        ],
+        surveysProps: [
+          {
+            name: 'Survey 1',
+            title: 'Survey Title',
+            description: 'Survey Description',
+            questions: [],
+            type: SurveyType.PRE,
+            uuid: 'uuid-1',
+            uniqueAnswer: false,
+            experimentId: 'exp-1',
+          },
+        ],
+        typeExperiment: 'within-subject',
+        betweenExperimentType: null,
+        icf: {title: 'ICF Title', description: 'ICF Description'},
+      };
+
+      const mockUser = {_id: 'owner-1', name: 'Owner'};
+      const savedExperiment = {_id: 'exp-1', name: 'Test Experiment'};
+      const savedSurvey = {_id: 'survey-1'};
+      const savedTask = {_id: 'task-1'};
+
+      mockUserService.findOne.mockResolvedValue(mockUser);
+      mockTransactionManager.findOne.mockResolvedValue(savedSurvey);
+      mockTransactionManager.save.mockImplementation(async (entity, payload) => {
+        if (entity === Experiment) {
+          return savedExperiment;
+        }
+        if (payload?.title === 'Task 1') {
+          return savedTask;
+        }
+        if (payload?.name === 'Survey 1') {
+          return savedSurvey;
+        }
+        return payload;
+      });
+      mockTaskSurveyInsertBuilder.execute.mockResolvedValue({});
+
+      const result = await service.create(createExperimentDto);
+
+      expect(mockUserService.findOne).toHaveBeenCalledWith('owner-1');
+      expect(mockExperimentRepository.manager.transaction).toHaveBeenCalled();
+      expect(mockTaskSurveyInsertBuilder.values).toHaveBeenCalled();
+      expect(mockTaskSurveyInsertBuilder.orIgnore).toHaveBeenCalled();
+      expect(result).toEqual(savedExperiment);
+    });
+
+    it('should keep backward compatibility when linkedSurveyRefs is not provided', async () => {
       const createExperimentDto: CreateExperimentDto = {
         name: 'Test Experiment',
         ownerId: 'owner-1',
@@ -178,7 +285,7 @@ describe('ExperimentService', () => {
             description: 'Survey Description',
             questions: [],
             type: SurveyType.PRE,
-            uuid: 'uuid-1',
+            uuid: 'survey-1',
             uniqueAnswer: false,
             experimentId: 'exp-1',
           },
@@ -188,24 +295,82 @@ describe('ExperimentService', () => {
         icf: {title: 'ICF Title', description: 'ICF Description'},
       };
 
-      const mockUser = {_id: 'owner-1', name: 'Owner'};
-      const savedExperiment = {_id: 'exp-1', ...createExperimentDto};
+      const savedExperiment = {_id: 'exp-1', name: 'Test Experiment'};
+      const savedSurvey = {_id: 'survey-1'};
 
-      mockUserService.findOne.mockResolvedValue(mockUser);
-      mockExperimentRepository.create.mockReturnValue(savedExperiment);
-      mockExperimentRepository.save.mockResolvedValue(savedExperiment);
-      mockSurveyService.create.mockResolvedValue({_id: 'survey-1'});
-      mockTaskService.create.mockResolvedValue({_id: 'task-1'});
-      mockIcfService.create.mockResolvedValue({_id: 'icf-1'});
+      mockUserService.findOne.mockResolvedValue({_id: 'owner-1'});
+      mockTransactionManager.findOne.mockResolvedValue(savedSurvey);
+      mockTransactionManager.save.mockImplementation(async (entity, payload) => {
+        if (entity === Experiment) {
+          return savedExperiment;
+        }
+        if (payload?.name === 'Survey 1') {
+          return savedSurvey;
+        }
+        return payload;
+      });
 
       const result = await service.create(createExperimentDto);
 
-      expect(mockUserService.findOne).toHaveBeenCalledWith('owner-1');
-      expect(mockExperimentRepository.save).toHaveBeenCalled();
-      expect(mockSurveyService.create).toHaveBeenCalled();
-      expect(mockTaskService.create).toHaveBeenCalled();
-      expect(mockIcfService.create).toHaveBeenCalled();
+      expect(mockTaskSurveyInsertBuilder.execute).not.toHaveBeenCalled();
       expect(result).toEqual(savedExperiment);
+    });
+
+    it('should throw 400 when linkedSurveyRefs contains invalid refs', async () => {
+      const createExperimentDto: CreateExperimentDto = {
+        name: 'Test Experiment',
+        ownerId: 'owner-1',
+        summary: 'Test Summary',
+        tasksProps: [
+          {
+            uuid: 'task-temp-1',
+            title: 'Task 1',
+            summary: 'Task Summary',
+            description: 'Task Description',
+            search_source: 'search-engine',
+            RulesExperiment: 'score',
+            ScoreThreshold: 0,
+            ScoreThresholdmx: 100,
+            selectedQuestionIds: [],
+            provider_config: {},
+            linkedSurveyRefs: ['missing-ref'],
+          },
+        ],
+        surveysProps: [
+          {
+            name: 'Survey 1',
+            title: 'Survey Title',
+            description: 'Survey Description',
+            questions: [],
+            type: SurveyType.PRE,
+            uuid: 'survey-1',
+            uniqueAnswer: false,
+            experimentId: 'exp-1',
+          },
+        ],
+        typeExperiment: 'within-subject',
+        betweenExperimentType: null,
+        icf: {title: 'ICF Title', description: 'ICF Description'},
+      };
+
+      mockUserService.findOne.mockResolvedValue({_id: 'owner-1'});
+      mockTransactionManager.save.mockImplementation(async (entity, payload) => {
+        if (entity === Experiment) {
+          return {_id: 'exp-1'};
+        }
+        if (payload?.name === 'Survey 1') {
+          return {_id: 'survey-1'};
+        }
+        if (payload?.title === 'Task 1') {
+          return {_id: 'task-1'};
+        }
+        return payload;
+      });
+
+      await expect(service.create(createExperimentDto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(mockTaskSurveyInsertBuilder.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/experiment/experiment.service.spec.ts
+++ b/src/modules/experiment/experiment.service.spec.ts
@@ -259,7 +259,7 @@ describe('ExperimentService', () => {
       expect(result).toEqual(savedExperiment);
     });
 
-    it('should keep backward compatibility when linkedSurveyRefs is not provided', async () => {
+    it('should keep backward compatibility by linking task_survey from SelectedSurvey when linkedSurveyRefs is not provided', async () => {
       const createExperimentDto: CreateExperimentDto = {
         name: 'Test Experiment',
         ownerId: 'owner-1',
@@ -306,6 +306,69 @@ describe('ExperimentService', () => {
         }
         if (payload?.name === 'Survey 1') {
           return savedSurvey;
+        }
+        return payload;
+      });
+
+      mockTaskSurveyInsertBuilder.execute.mockResolvedValue({});
+
+      const result = await service.create(createExperimentDto);
+
+      expect(mockTaskSurveyInsertBuilder.values).toHaveBeenCalledWith([
+        expect.objectContaining({survey_id: 'survey-1'}),
+      ]);
+      expect(mockTaskSurveyInsertBuilder.execute).toHaveBeenCalled();
+      expect(result).toEqual(savedExperiment);
+    });
+
+    it('should keep behavior unchanged when no linked survey fields are provided', async () => {
+      const createExperimentDto: CreateExperimentDto = {
+        name: 'Test Experiment',
+        ownerId: 'owner-1',
+        summary: 'Test Summary',
+        tasksProps: [
+          {
+            title: 'Task 1',
+            summary: 'Task Summary',
+            description: 'Task Description',
+            search_source: 'search-engine',
+            RulesExperiment: 'score',
+            ScoreThreshold: 0,
+            ScoreThresholdmx: 100,
+            selectedQuestionIds: [],
+            provider_config: {},
+          },
+        ],
+        surveysProps: [
+          {
+            name: 'Survey 1',
+            title: 'Survey Title',
+            description: 'Survey Description',
+            questions: [],
+            type: SurveyType.PRE,
+            uuid: 'survey-1',
+            uniqueAnswer: false,
+            experimentId: 'exp-1',
+          },
+        ],
+        typeExperiment: 'within-subject',
+        betweenExperimentType: null,
+        icf: {title: 'ICF Title', description: 'ICF Description'},
+      };
+
+      const savedExperiment = {_id: 'exp-1', name: 'Test Experiment'};
+      const savedSurvey = {_id: 'survey-1'};
+
+      mockUserService.findOne.mockResolvedValue({_id: 'owner-1'});
+      mockTransactionManager.save.mockImplementation(async (entity, payload) => {
+        if (entity === Experiment) {
+          return savedExperiment;
+        }
+        if (payload?.name === 'Survey 1') {
+          return savedSurvey;
+        }
+        if (payload?.title === 'Task 1') {
+          return {_id: 'task-1'};
         }
         return payload;
       });

--- a/src/modules/experiment/experiment.service.spec.ts
+++ b/src/modules/experiment/experiment.service.spec.ts
@@ -3,20 +3,24 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import type { TestingModule } from '@nestjs/testing';
-import { Test } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import type {TestingModule} from '@nestjs/testing';
+import {Test} from '@nestjs/testing';
+import {getRepositoryToken} from '@nestjs/typeorm';
 
-import { IcfService } from '../icf/icf.service';
-import { SurveyType } from '../survey/entity/survey.entity';
-import { SurveyService } from '../survey/survey.service';
-import { TaskService } from '../task/task.service';
-import { UserService } from '../user/user.service';
-import { UserExperimentService } from '../user-experiment/user-experiment.service';
-import { UserTaskService } from '../user-task/user-task.service';
-import type { CreateExperimentDto } from './dto/create-experiment.dto';
-import { Experiment, ExperimentStatus,StepsType } from './entity/experiment.entity';
-import { ExperimentService } from './experiment.service';
+import {IcfService} from '../icf/icf.service';
+import {SurveyType} from '../survey/entity/survey.entity';
+import {SurveyService} from '../survey/survey.service';
+import {TaskService} from '../task/task.service';
+import {UserService} from '../user/user.service';
+import {UserExperimentService} from '../user-experiment/user-experiment.service';
+import {UserTaskService} from '../user-task/user-task.service';
+import type {CreateExperimentDto} from './dto/create-experiment.dto';
+import {
+  Experiment,
+  ExperimentStatus,
+  StepsType,
+} from './entity/experiment.entity';
+import {ExperimentService} from './experiment.service';
 
 describe('ExperimentService', () => {
   let service: ExperimentService;
@@ -24,10 +28,17 @@ describe('ExperimentService', () => {
     find: jest.Mock;
     findOneBy: jest.Mock;
     findOne: jest.Mock;
+    createQueryBuilder: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
     update: jest.Mock;
     delete: jest.Mock;
+  };
+  let mockExperimentQueryBuilder: {
+    leftJoinAndSelect: jest.Mock;
+    addSelect: jest.Mock;
+    where: jest.Mock;
+    getOne: jest.Mock;
   };
   let mockUserExperimentService: {
     getDetailedStats: jest.Mock;
@@ -58,11 +69,21 @@ describe('ExperimentService', () => {
       find: jest.fn(),
       findOneBy: jest.fn(),
       findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
     };
+    mockExperimentQueryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    };
+    mockExperimentRepository.createQueryBuilder.mockReturnValue(
+      mockExperimentQueryBuilder,
+    );
 
     mockUserExperimentService = {
       getDetailedStats: jest.fn(),
@@ -164,18 +185,18 @@ describe('ExperimentService', () => {
         ],
         typeExperiment: 'within-subject',
         betweenExperimentType: null,
-        icf: { title: 'ICF Title', description: 'ICF Description' },
+        icf: {title: 'ICF Title', description: 'ICF Description'},
       };
 
-      const mockUser = { _id: 'owner-1', name: 'Owner' };
-      const savedExperiment = { _id: 'exp-1', ...createExperimentDto };
+      const mockUser = {_id: 'owner-1', name: 'Owner'};
+      const savedExperiment = {_id: 'exp-1', ...createExperimentDto};
 
       mockUserService.findOne.mockResolvedValue(mockUser);
       mockExperimentRepository.create.mockReturnValue(savedExperiment);
       mockExperimentRepository.save.mockResolvedValue(savedExperiment);
-      mockSurveyService.create.mockResolvedValue({ _id: 'survey-1' });
-      mockTaskService.create.mockResolvedValue({ _id: 'task-1' });
-      mockIcfService.create.mockResolvedValue({ _id: 'icf-1' });
+      mockSurveyService.create.mockResolvedValue({_id: 'survey-1'});
+      mockTaskService.create.mockResolvedValue({_id: 'task-1'});
+      mockIcfService.create.mockResolvedValue({_id: 'icf-1'});
 
       const result = await service.create(createExperimentDto);
 
@@ -191,8 +212,8 @@ describe('ExperimentService', () => {
   describe('findAll', () => {
     it('should return all experiments', async () => {
       const experiments = [
-        { _id: 'exp-1', name: 'Experiment 1' },
-        { _id: 'exp-2', name: 'Experiment 2' },
+        {_id: 'exp-1', name: 'Experiment 1'},
+        {_id: 'exp-2', name: 'Experiment 2'},
       ];
 
       mockExperimentRepository.find.mockResolvedValue(experiments);
@@ -206,7 +227,7 @@ describe('ExperimentService', () => {
 
   describe('find', () => {
     it('should find an experiment by id', async () => {
-      const experiment = { _id: 'exp-1', name: 'Experiment 1' };
+      const experiment = {_id: 'exp-1', name: 'Experiment 1'};
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
 
       const result = await service.find('exp-1');
@@ -220,7 +241,7 @@ describe('ExperimentService', () => {
 
   describe('getStats', () => {
     it('should return experiment stats', async () => {
-      const stats = { totalParticipants: 10, completedTasks: 8 };
+      const stats = {totalParticipants: 10, completedTasks: 8};
       mockUserExperimentService.getDetailedStats.mockResolvedValue(stats);
 
       const result = await service.getStats('exp-1');
@@ -235,8 +256,8 @@ describe('ExperimentService', () => {
   describe('getParticipants', () => {
     it('should return experiment participants', async () => {
       const participants = [
-        { userId: 'user-1', status: 'completed' },
-        { userId: 'user-2', status: 'pending' },
+        {userId: 'user-1', status: 'completed'},
+        {userId: 'user-2', status: 'pending'},
       ];
       mockUserExperimentService.getParticipantsDetails.mockResolvedValue(
         participants,
@@ -256,14 +277,14 @@ describe('ExperimentService', () => {
       const experiment = {
         _id: 'exp-1',
         name: 'Experiment 1',
-        tasks: [{ _id: 'task-1', title: 'Task 1' }],
+        tasks: [{_id: 'task-1', title: 'Task 1'}],
       };
       mockExperimentRepository.findOne.mockResolvedValue(experiment);
 
       const result = await service.findWithTasks('exp-1');
 
       expect(mockExperimentRepository.findOne).toHaveBeenCalledWith({
-        where: { _id: 'exp-1' },
+        where: {_id: 'exp-1'},
         relations: ['tasks'],
       });
       expect(result).toEqual(experiment);
@@ -273,14 +294,14 @@ describe('ExperimentService', () => {
   describe('getTasksExecutionDetails', () => {
     it('should return tasks execution details grouped by task', async () => {
       const userTasks = [
-        { task_id: 'task-1', task: { title: 'Task 1' }, execution: 'data-1' },
-        { task_id: 'task-1', task: { title: 'Task 1' }, execution: 'data-2' },
+        {task_id: 'task-1', task: {title: 'Task 1'}, execution: 'data-1'},
+        {task_id: 'task-1', task: {title: 'Task 1'}, execution: 'data-2'},
       ];
 
       mockUserTaskService.findByExperimentId.mockResolvedValue(userTasks);
       mockUserTaskService.getExecutionDetailsFromEntity
-        .mockResolvedValueOnce({ details: 'execution-1' })
-        .mockResolvedValueOnce({ details: 'execution-2' });
+        .mockResolvedValueOnce({details: 'execution-1'})
+        .mockResolvedValueOnce({details: 'execution-2'});
 
       const result = await service.getTasksExecutionDetails('exp-1');
 
@@ -296,14 +317,14 @@ describe('ExperimentService', () => {
   describe('getSurveysStats', () => {
     it('should return surveys statistics', async () => {
       const surveys = [
-        { _id: 'survey-1', title: 'Survey 1' },
-        { _id: 'survey-2', title: 'Survey 2' },
+        {_id: 'survey-1', title: 'Survey 1'},
+        {_id: 'survey-2', title: 'Survey 2'},
       ];
 
       mockSurveyService.findByExperimentId.mockResolvedValue(surveys);
       mockSurveyService.getStats
-        .mockResolvedValueOnce({ responses: 10 })
-        .mockResolvedValueOnce({ responses: 8 });
+        .mockResolvedValueOnce({responses: 10})
+        .mockResolvedValueOnce({responses: 8});
 
       const result = await service.getSurveysStats('exp-1');
 
@@ -316,16 +337,19 @@ describe('ExperimentService', () => {
 
   describe('update', () => {
     it('should update an experiment', async () => {
-      const updateDto = { name: 'Updated Experiment', status: ExperimentStatus.IN_PROGRESS };
-      const updatedExperiment = { _id: 'exp-1', ...updateDto };
+      const updateDto = {
+        name: 'Updated Experiment',
+        status: ExperimentStatus.IN_PROGRESS,
+      };
+      const updatedExperiment = {_id: 'exp-1', ...updateDto};
 
-      mockExperimentRepository.update.mockResolvedValue({ affected: 1 });
+      mockExperimentRepository.update.mockResolvedValue({affected: 1});
       mockExperimentRepository.findOneBy.mockResolvedValue(updatedExperiment);
 
       const result = await service.update('exp-1', updateDto);
 
       expect(mockExperimentRepository.update).toHaveBeenCalledWith(
-        { _id: 'exp-1' },
+        {_id: 'exp-1'},
         updateDto,
       );
       expect(result).toEqual(updatedExperiment);
@@ -334,9 +358,9 @@ describe('ExperimentService', () => {
 
   describe('remove', () => {
     it('should remove an experiment', async () => {
-      const experiment = { _id: 'exp-1', name: 'Experiment 1' };
+      const experiment = {_id: 'exp-1', name: 'Experiment 1'};
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
-      mockExperimentRepository.delete.mockResolvedValue({ affected: 1 });
+      mockExperimentRepository.delete.mockResolvedValue({affected: 1});
 
       const result = await service.remove('exp-1');
 
@@ -351,11 +375,11 @@ describe('ExperimentService', () => {
     it('should build experiment steps correctly', async () => {
       const experiment = {
         _id: 'exp-1',
-        icfs: [{ _id: 'icf-1' }],
-        tasks: [{ _id: 'task-1' }],
+        icfs: [{_id: 'icf-1'}],
+        tasks: [{_id: 'task-1'}],
         surveys: [
-          { _id: 'survey-1', type: SurveyType.PRE },
-          { _id: 'survey-2', type: SurveyType.POST },
+          {_id: 'survey-1', type: SurveyType.PRE},
+          {_id: 'survey-2', type: SurveyType.POST},
         ],
       };
 
@@ -378,7 +402,7 @@ describe('ExperimentService', () => {
         summary: 'Test Summary',
         typeExperiment: 'within-subject',
         betweenExperimentType: null,
-        icfs: [{ title: 'ICF Title', description: 'ICF Description' }],
+        icfs: [{title: 'ICF Title', description: 'ICF Description'}],
         surveys: [
           {
             name: 'Survey 1',
@@ -398,22 +422,33 @@ describe('ExperimentService', () => {
             rule_type: 'score',
             max_score: 100,
             min_score: 0,
-            search_source: 'search-engine',
+            search_source: 'llm',
+            provider_config: {
+              modelProvider: 'google',
+              model: 'gemini-2.5-flash',
+              systemInstruction: 'Answer as a research assistant.',
+              apiKey: 'secret-api-key',
+            },
             survey_id: 'survey-1',
           },
         ],
       };
 
-      mockExperimentRepository.findOne.mockResolvedValue(experiment);
+      mockExperimentQueryBuilder.getOne.mockResolvedValue(experiment);
 
       const result = await service.exportToYaml('exp-1');
 
       expect(typeof result).toBe('string');
       expect(result).toContain('Test Experiment');
+      expect(result).toContain(
+        'systemInstruction: Answer as a research assistant.',
+      );
+      expect(result).toContain('search_model: gemini-2.5-flash');
+      expect(result).not.toContain('secret-api-key');
     });
 
     it('should throw error if experiment not found', async () => {
-      mockExperimentRepository.findOne.mockResolvedValue(null);
+      mockExperimentQueryBuilder.getOne.mockResolvedValue(null);
 
       await expect(service.exportToYaml('exp-1')).rejects.toThrow(
         'Experiment not found',
@@ -447,14 +482,16 @@ describe('ExperimentService', () => {
             - title: Task 1
               summary: Task Summary
               description: Task Description
-              search_source: search-engine
+              search_source: llm
+              search_model: gemini-2.5-flash
+              systemInstruction: Answer as a research assistant.
               rule_type: score
               min_score: 0
               max_score: 100
       `;
 
-      const mockUser = { _id: 'owner-1' };
-      const savedExperiment = { _id: 'exp-1', name: 'Test Import' };
+      const mockUser = {_id: 'owner-1'};
+      const savedExperiment = {_id: 'exp-1', name: 'Test Import'};
 
       mockUserService.findOne.mockResolvedValue(mockUser);
       mockExperimentRepository.create.mockReturnValue(savedExperiment);
@@ -467,6 +504,15 @@ describe('ExperimentService', () => {
 
       expect(result).toEqual([]);
       expect(mockExperimentRepository.save).toHaveBeenCalled();
+      expect(mockTaskService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_config: expect.objectContaining({
+            modelProvider: 'google',
+            model: 'gemini-2.5-flash',
+            systemInstruction: 'Answer as a research assistant.',
+          }),
+        }),
+      );
     });
 
     it('should return validation errors for invalid YAML', async () => {
@@ -484,8 +530,8 @@ describe('ExperimentService', () => {
 
   describe('getGeneralExpirementInfos', () => {
     it('should return general experiment information', async () => {
-      const experiment = { _id: 'exp-1', status: 'active' };
-      const userInfos = { total: 10, completed: 8 };
+      const experiment = {_id: 'exp-1', status: 'active'};
+      const userInfos = {total: 10, completed: 8};
 
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
       mockUserExperimentService.countUsersByExperimentId.mockResolvedValue(
@@ -501,7 +547,7 @@ describe('ExperimentService', () => {
 
   describe('findOneByName', () => {
     it('should find experiment by name', async () => {
-      const experiment = { _id: 'exp-1', name: 'Test Experiment' };
+      const experiment = {_id: 'exp-1', name: 'Test Experiment'};
       mockExperimentRepository.findOneBy.mockResolvedValue(experiment);
 
       const result = await service.findOneByName('Test Experiment');
@@ -515,13 +561,13 @@ describe('ExperimentService', () => {
 
   describe('findByOwnerId', () => {
     it('should find experiments by owner id', async () => {
-      const experiments = [{ _id: 'exp-1', owner_id: 'owner-1' }];
+      const experiments = [{_id: 'exp-1', owner_id: 'owner-1'}];
       mockExperimentRepository.find.mockResolvedValue(experiments);
 
       const result = await service.findByOwnerId('owner-1');
 
       expect(mockExperimentRepository.find).toHaveBeenCalledWith({
-        where: { owner_id: 'owner-1' },
+        where: {owner_id: 'owner-1'},
       });
       expect(result).toEqual(experiments);
     });

--- a/src/modules/experiment/experiment.service.ts
+++ b/src/modules/experiment/experiment.service.ts
@@ -3,17 +3,26 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import {forwardRef, Inject, Injectable} from '@nestjs/common';
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import * as yaml from 'js-yaml';
 import {Repository} from 'typeorm';
 
+import {Icf} from '../icf/entity/icf.entity';
 import {IcfService} from '../icf/icf.service';
 import {QuestionDTO, QuestionType} from '../survey/dto/question.dto';
+import {Survey} from '../survey/entity/survey.entity';
 import {SurveyType} from '../survey/entity/survey.entity';
 import {SurveyService} from '../survey/survey.service';
 import {Task, TaskProviderConfig} from '../task/entities/task.entity';
 import {TaskService} from '../task/task.service';
+import {TaskQuestionMap} from '../task-question-map/entity/taskQuestionMap.entity';
+import {TaskSurvey} from '../task-survey/entity/taskSurvey.entity';
 import {UserService} from '../user/user.service';
 import {UserExperimentService} from '../user-experiment/user-experiment.service';
 import {UserTask} from '../user-task/entities/user-tasks.entity';
@@ -117,61 +126,200 @@ export class ExperimentService {
       name,
       ownerId,
       summary,
-      tasksProps,
-      surveysProps,
+      tasksProps = [],
+      surveysProps = [],
       typeExperiment,
       betweenExperimentType,
       icf,
     } = createExperimentDto;
 
     const owner = await this.userService.findOne(ownerId);
-    const experiment = await this.experimentRepository.create({
-      name,
-      summary,
-      owner_id: ownerId,
-      owner,
-      typeExperiment,
-      betweenExperimentType,
-    });
-    const savedExperiment = await this.experimentRepository.save(experiment);
+    return await this.experimentRepository.manager.transaction(
+      async (manager) => {
+          const savedExperiment = await manager.save(
+            Experiment,
+            manager.create(Experiment, {
+              name,
+              summary,
+              owner_id: ownerId,
+              owner,
+              typeExperiment,
+              betweenExperimentType,
+            }),
+          );
 
-    const SurveysPromises = surveysProps.map((survey) => {
-      return this.surveyService.create({
-        description: survey.description,
-        name: survey.name,
-        title: survey.title,
-        questions: survey.questions,
-        type: survey.type,
-        experimentId: savedExperiment._id,
-        uuid: survey.uuid,
-        uniqueAnswer: survey.uniqueAnswer,
-      });
-    });
-    await Promise.all(SurveysPromises);
+          const createdSurveys = await Promise.all(
+            surveysProps.map((survey) => {
+              const surveyData: Partial<Survey> = {
+                name: survey.name,
+                title: survey.title,
+                description: survey.description,
+                type: survey.type,
+                questions: survey.questions,
+                uniqueAnswer: survey.uniqueAnswer,
+                experiment: savedExperiment,
+              };
 
-    const TasksPromises = tasksProps.map((task) => {
-      return this.taskService.create({
-        title: task.title,
-        summary: task.summary,
-        description: task.description,
-        search_source: task.search_source,
-        survey_id: task.SelectedSurvey,
-        rule_type: task.RulesExperiment,
-        min_score: task.ScoreThreshold,
-        max_score: task.ScoreThresholdmx,
-        questionsId: task.selectedQuestionIds,
-        experiment_id: savedExperiment._id,
-        provider_config: task.provider_config,
-      });
-    });
-    await Promise.all(TasksPromises);
+              if (survey.uuid) {
+                surveyData._id = survey.uuid;
+              }
 
-    await this.icfService.create({
-      title: icf.title,
-      description: icf.description,
-      experimentId: savedExperiment._id,
-    });
-    return savedExperiment;
+              return manager.save(Survey, manager.create(Survey, surveyData));
+            }),
+          );
+
+          const surveyRefToId = new Map<string, string>();
+          const createdSurveyMap = new Map<string, Survey>();
+          createdSurveys.forEach((survey, index) => {
+            surveyRefToId.set(survey._id, survey._id);
+            createdSurveyMap.set(survey._id, survey);
+
+            const originalRef = surveysProps[index]?.uuid;
+            if (originalRef) {
+              surveyRefToId.set(originalRef, survey._id);
+            }
+          });
+
+          const createdTasks = await Promise.all(
+            tasksProps.map(async (task) => {
+              let linkedSurvey: Survey | null = null;
+              if (task.SelectedSurvey) {
+                const selectedSurveyId =
+                  surveyRefToId.get(task.SelectedSurvey) || task.SelectedSurvey;
+
+                linkedSurvey = await manager.findOne(Survey, {
+                  where: {_id: selectedSurveyId},
+                });
+
+                if (!linkedSurvey) {
+                  throw new BadRequestException({
+                    message: 'Invalid SelectedSurvey reference',
+                    taskRef: task.uuid || task.title,
+                    ref: task.SelectedSurvey,
+                  });
+                }
+              }
+
+              const createdTask = await manager.save(
+                Task,
+                manager.create(Task, {
+                  title: task.title,
+                  summary: task.summary,
+                  description: task.description,
+                  search_source: task.search_source,
+                  survey: linkedSurvey,
+                  survey_id: linkedSurvey?._id || null,
+                  rule_type: task.RulesExperiment,
+                  min_score: task.ScoreThreshold || 0,
+                  max_score: task.ScoreThresholdmx || 0,
+                  experiment: savedExperiment,
+                  provider_config: task.provider_config,
+                }),
+              );
+
+              if (task.selectedQuestionIds?.length > 0) {
+                const questionRows = task.selectedQuestionIds.map((questionId) =>
+                  manager.create(TaskQuestionMap, {
+                    task: createdTask,
+                    task_id: createdTask._id,
+                    question_id: questionId,
+                  }),
+                );
+                await manager.save(TaskQuestionMap, questionRows);
+              }
+
+              return {task: createdTask, payload: task};
+            }),
+          );
+
+          const invalidRefs: Array<{
+            taskRef: string;
+            invalidRefs: string[];
+          }> = [];
+          const pairSet = new Set<string>();
+          const rowsToLink: TaskSurvey[] = [];
+
+          createdTasks.forEach(({task, payload}, index) => {
+            const refs = payload.linkedSurveyRefs || [];
+            if (refs.length === 0) {
+              return;
+            }
+
+            const uniqueRefs = [...new Set(refs)];
+            const unresolvedRefs = uniqueRefs.filter(
+              (ref) => !surveyRefToId.has(ref),
+            );
+
+            if (unresolvedRefs.length > 0) {
+              invalidRefs.push({
+                taskRef: payload.uuid || payload.title || `task_${index + 1}`,
+                invalidRefs: unresolvedRefs,
+              });
+              return;
+            }
+
+            uniqueRefs.forEach((ref) => {
+              const surveyId = surveyRefToId.get(ref);
+              const survey = surveyId ? createdSurveyMap.get(surveyId) : undefined;
+              if (!surveyId || !survey) {
+                invalidRefs.push({
+                  taskRef: payload.uuid || payload.title || `task_${index + 1}`,
+                  invalidRefs: [ref],
+                });
+                return;
+              }
+
+              const pairKey = `${task._id}:${surveyId}`;
+              if (pairSet.has(pairKey)) {
+                return;
+              }
+
+              pairSet.add(pairKey);
+              rowsToLink.push(
+                manager.create(TaskSurvey, {
+                  task,
+                  task_id: task._id,
+                  survey,
+                  survey_id: surveyId,
+                }),
+              );
+            });
+          });
+
+          if (invalidRefs.length > 0) {
+            throw new BadRequestException({
+              message: 'Invalid survey references in tasksProps.linkedSurveyRefs',
+              details: invalidRefs,
+            });
+          }
+
+          if (rowsToLink.length > 0) {
+            await manager
+              .createQueryBuilder()
+              .insert()
+              .into(TaskSurvey)
+              .values(
+                rowsToLink.map((row) => ({
+                  task_id: row.task_id,
+                  survey_id: row.survey_id,
+                })),
+              )
+              .orIgnore()
+              .execute();
+          }
+
+          await manager.save(
+            Icf,
+            manager.create(Icf, {
+              title: icf.title,
+              description: icf.description,
+              experiment: savedExperiment,
+            }),
+          );
+
+          return savedExperiment;
+      },
+    );
   }
 
   async findAll(): Promise<Experiment[]> {

--- a/src/modules/experiment/experiment.service.ts
+++ b/src/modules/experiment/experiment.service.ts
@@ -221,6 +221,11 @@ export class ExperimentService {
       result.push({
         taskId: taskId,
         taskTitle: data.task.title,
+        taskType: data.task.search_source,
+        systemInstruction:
+          data.task.search_source === 'llm'
+            ? data.task.provider_config?.systemInstruction ?? null
+            : null,
         executions: executionsDetails,
       });
     }

--- a/src/modules/experiment/experiment.service.ts
+++ b/src/modules/experiment/experiment.service.ts
@@ -240,7 +240,10 @@ export class ExperimentService {
           const rowsToLink: TaskSurvey[] = [];
 
           createdTasks.forEach(({task, payload}, index) => {
-            const refs = payload.linkedSurveyRefs || [];
+            const refs = [
+              ...(payload.linkedSurveyRefs || []),
+              ...(payload.SelectedSurvey ? [payload.SelectedSurvey] : []),
+            ];
             if (refs.length === 0) {
               return;
             }

--- a/src/modules/experiment/experiment.service.ts
+++ b/src/modules/experiment/experiment.service.ts
@@ -9,14 +9,14 @@ import * as yaml from 'js-yaml';
 import {Repository} from 'typeorm';
 
 import {IcfService} from '../icf/icf.service';
-import { QuestionDTO, QuestionType } from '../survey/dto/question.dto';
-import { SurveyType } from '../survey/entity/survey.entity';
+import {QuestionDTO, QuestionType} from '../survey/dto/question.dto';
+import {SurveyType} from '../survey/entity/survey.entity';
 import {SurveyService} from '../survey/survey.service';
-import { Task } from '../task/entities/task.entity';
+import {Task, TaskProviderConfig} from '../task/entities/task.entity';
 import {TaskService} from '../task/task.service';
 import {UserService} from '../user/user.service';
 import {UserExperimentService} from '../user-experiment/user-experiment.service';
-import { UserTask } from '../user-task/entities/user-tasks.entity';
+import {UserTask} from '../user-task/entities/user-tasks.entity';
 import {UserTaskService} from '../user-task/user-task.service';
 import {CreateExperimentDto} from './dto/create-experiment.dto';
 import {ExperimentParticipantDto} from './dto/experiment-participant.dto';
@@ -61,6 +61,9 @@ type YamlTask = {
   max_score?: number;
   min_score?: number;
   search_source?: string;
+  search_model?: string;
+  systemInstruction?: string;
+  provider_config?: TaskProviderConfig;
   survey_id?: string | null;
 };
 
@@ -224,7 +227,7 @@ export class ExperimentService {
         taskType: data.task.search_source,
         systemInstruction:
           data.task.search_source === 'llm'
-            ? data.task.provider_config?.systemInstruction ?? null
+            ? (data.task.provider_config?.systemInstruction ?? null)
             : null,
         executions: executionsDetails,
       });
@@ -259,9 +262,9 @@ export class ExperimentService {
     id: string,
     updateExperimentDto: UpdateExperimentDto,
   ): Promise<Experiment> {
-      await this.experimentRepository.update({_id: id}, updateExperimentDto);
-      const result = await this.find(id);
-      return result;
+    await this.experimentRepository.update({_id: id}, updateExperimentDto);
+    const result = await this.find(id);
+    return result;
   }
 
   async remove(id: string) {
@@ -312,10 +315,14 @@ export class ExperimentService {
   }
 
   async exportToYaml(id: string): Promise<string> {
-    const experiment = await this.experimentRepository.findOne({
-      where: {_id: id},
-      relations: ['tasks', 'surveys', 'icfs'],
-    });
+    const experiment = await this.experimentRepository
+      .createQueryBuilder('experiment')
+      .leftJoinAndSelect('experiment.tasks', 'task')
+      .addSelect('task.provider_config')
+      .leftJoinAndSelect('experiment.surveys', 'survey')
+      .leftJoinAndSelect('experiment.icfs', 'icf')
+      .where('experiment._id = :id', {id})
+      .getOne();
 
     if (!experiment) {
       throw new Error('Experiment not found');
@@ -347,20 +354,93 @@ export class ExperimentService {
             required: survey.required,
           })) || [],
         tasks:
-          experiment.tasks?.map((task) => ({
-            title: task.title,
-            summary: task.summary,
-            description: task.description,
-            rule_type: task.rule_type,
-            max_score: task.max_score,
-            min_score: task.min_score,
-            search_source: task.search_source,
-            survey_id: task.survey_id,
-          })) || [],
+          experiment.tasks?.map((task) => {
+            const providerConfig = this.buildYamlProviderConfig(task);
+            const yamlTask: YamlTask = {
+              title: task.title,
+              summary: task.summary,
+              description: task.description,
+              rule_type: task.rule_type,
+              max_score: task.max_score,
+              min_score: task.min_score,
+              search_source: task.search_source,
+              survey_id: task.survey_id,
+            };
+
+            const searchModel =
+              providerConfig?.model || providerConfig?.searchProvider;
+            if (searchModel) {
+              yamlTask.search_model = searchModel;
+            }
+            if (providerConfig?.systemInstruction) {
+              yamlTask.systemInstruction = providerConfig.systemInstruction;
+            }
+            if (providerConfig) {
+              yamlTask.provider_config = providerConfig;
+            }
+
+            return yamlTask;
+          }) || [],
       },
     };
 
     return yaml.dump(yamlData);
+  }
+
+  private buildYamlProviderConfig(task: Task): TaskProviderConfig | undefined {
+    const providerConfig = task.provider_config || {};
+    const yamlProviderConfig: TaskProviderConfig = {};
+
+    if (task.search_source === 'llm') {
+      if (providerConfig.modelProvider) {
+        yamlProviderConfig.modelProvider = providerConfig.modelProvider;
+      }
+      if (providerConfig.model) {
+        yamlProviderConfig.model = providerConfig.model;
+      }
+      if (providerConfig.systemInstruction) {
+        yamlProviderConfig.systemInstruction = providerConfig.systemInstruction;
+      }
+    }
+
+    if (
+      task.search_source === 'search-engine' &&
+      providerConfig.searchProvider
+    ) {
+      yamlProviderConfig.searchProvider = providerConfig.searchProvider;
+    }
+
+    return Object.keys(yamlProviderConfig).length > 0
+      ? yamlProviderConfig
+      : undefined;
+  }
+
+  private buildProviderConfigFromYaml(
+    task: YamlTask,
+  ): TaskProviderConfig | undefined {
+    const providerConfig: TaskProviderConfig = {
+      ...(task.provider_config || {}),
+    };
+
+    if (task.search_source === 'llm') {
+      providerConfig.modelProvider = providerConfig.modelProvider || 'google';
+      if (task.search_model && !providerConfig.model) {
+        providerConfig.model = task.search_model;
+      }
+      if (task.systemInstruction && !providerConfig.systemInstruction) {
+        providerConfig.systemInstruction = task.systemInstruction;
+      }
+    }
+
+    if (
+      task.search_source === 'search-engine' &&
+      task.search_model &&
+      !providerConfig.searchProvider
+    ) {
+      providerConfig.searchProvider = task.search_model;
+    }
+
+    return Object.keys(providerConfig).length > 0 ? providerConfig : undefined;
   }
 
   async importFromYaml(
@@ -446,6 +526,7 @@ export class ExperimentService {
             max_score: task.max_score || 0,
             questionsId: [],
             experiment_id: savedExperiment._id,
+            provider_config: this.buildProviderConfigFromYaml(task),
           });
         });
         await Promise.all(tasksPromises);
@@ -456,7 +537,7 @@ export class ExperimentService {
       console.error('Error importing YAML:', error);
       throw new Error(
         `Failed to import experiment: ${error instanceof Error ? error.message : 'unknown error'}`,
-        { cause: error },
+        {cause: error},
       );
     }
   }

--- a/src/modules/llm-session/constants/llm-provider-registry.constants.ts
+++ b/src/modules/llm-session/constants/llm-provider-registry.constants.ts
@@ -8,9 +8,12 @@ export type LlmProviderRegistryEntry = {
   label: string;
   defaultModel: string;
   suggestedModels: string[];
+  public: boolean;
   baseURL?: string;
   defaultHeaders?: Record<string, string>;
 };
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
 export const LLM_PROVIDER_REGISTRY: Record<string, LlmProviderRegistryEntry> = {
   openrouter: {
@@ -23,12 +26,131 @@ export const LLM_PROVIDER_REGISTRY: Record<string, LlmProviderRegistryEntry> = {
       'anthropic/claude-3.5-sonnet',
       'google/gemini-2.5-flash',
     ],
-    baseURL: 'https://openrouter.ai/api/v1',
+    public: false,
+    baseURL: OPENROUTER_BASE_URL,
   },
   openai: {
     value: 'openai',
     label: 'OpenAI',
-    defaultModel: 'gpt-4o-mini',
-    suggestedModels: ['gpt-4o-mini', 'gpt-4o'],
+    defaultModel: 'openai/gpt-4o-mini',
+    suggestedModels: [
+      'openai/gpt-4o-mini',
+      'openai/gpt-4o',
+      'openai/gpt-4.1-mini',
+      'openai/gpt-4.1',
+      'openai/o4-mini',
+    ],
+    public: true,
+    baseURL: OPENROUTER_BASE_URL,
   },
+  anthropic: {
+    value: 'anthropic',
+    label: 'Anthropic',
+    defaultModel: 'anthropic/claude-3.5-sonnet',
+    suggestedModels: [
+      'anthropic/claude-3.5-sonnet',
+      'anthropic/claude-3.7-sonnet',
+      'anthropic/claude-3.5-haiku',
+    ],
+    public: true,
+    baseURL: OPENROUTER_BASE_URL,
+  },
+  google: {
+    value: 'google',
+    label: 'Google',
+    defaultModel: 'google/gemini-2.5-flash',
+    suggestedModels: [
+      'google/gemini-2.5-flash',
+      'google/gemini-2.5-pro',
+      'google/gemini-2.0-flash-001',
+      'google/gemini-2.0-flash-lite-001',
+    ],
+    public: true,
+    baseURL: OPENROUTER_BASE_URL,
+  },
+  meta: {
+    value: 'meta',
+    label: 'Meta',
+    defaultModel: 'meta-llama/llama-3.3-70b-instruct',
+    suggestedModels: [
+      'meta-llama/llama-3.3-70b-instruct',
+      'meta-llama/llama-3.1-405b-instruct',
+      'meta-llama/llama-3.1-70b-instruct',
+      'meta-llama/llama-3.1-8b-instruct',
+    ],
+    public: true,
+    baseURL: OPENROUTER_BASE_URL,
+  },
+  mistral: {
+    value: 'mistral',
+    label: 'Mistral',
+    defaultModel: 'mistralai/mistral-large',
+    suggestedModels: [
+      'mistralai/mistral-large',
+      'mistralai/mistral-small',
+      'mistralai/codestral',
+    ],
+    public: true,
+    baseURL: OPENROUTER_BASE_URL,
+  },
+  deepseek: {
+    value: 'deepseek',
+    label: 'DeepSeek',
+    defaultModel: 'deepseek/deepseek-chat-v3-0324',
+    suggestedModels: [
+      'deepseek/deepseek-chat-v3-0324',
+      'deepseek/deepseek-r1',
+    ],
+    public: true,
+    baseURL: OPENROUTER_BASE_URL,
+  },
+};
+
+const MODEL_PREFIX_PROVIDER_MAP: Record<string, string> = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  google: 'google',
+  meta: 'meta',
+  'meta-llama': 'meta',
+  mistralai: 'mistral',
+  deepseek: 'deepseek',
+};
+
+export const inferProviderFromModel = (model?: string): string | undefined => {
+  if (!model) {
+    return undefined;
+  }
+
+  const [prefix] = model.split('/');
+  return MODEL_PREFIX_PROVIDER_MAP[prefix];
+};
+
+export const resolveLlmProvider = (
+  provider?: string,
+  model?: string,
+): LlmProviderRegistryEntry | undefined => {
+  if (provider && LLM_PROVIDER_REGISTRY[provider]) {
+    return LLM_PROVIDER_REGISTRY[provider];
+  }
+
+  const inferredProvider = inferProviderFromModel(model);
+  if (inferredProvider) {
+    return LLM_PROVIDER_REGISTRY[inferredProvider];
+  }
+
+  return undefined;
+};
+
+export const getPublicLlmProviderEntries = (): LlmProviderRegistryEntry[] =>
+  Object.values(LLM_PROVIDER_REGISTRY).filter((entry) => entry.public);
+
+export const getDisplayProviderValue = (
+  provider?: string,
+  model?: string,
+): string | undefined => {
+  if (provider && provider !== 'openrouter' && LLM_PROVIDER_REGISTRY[provider]?.public) {
+    return provider;
+  }
+
+  return inferProviderFromModel(model);
 };

--- a/src/modules/llm-session/constants/llm-provider-registry.constants.ts
+++ b/src/modules/llm-session/constants/llm-provider-registry.constants.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+export type LlmProviderRegistryEntry = {
+  value: string;
+  label: string;
+  defaultModel: string;
+  suggestedModels: string[];
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
+};
+
+export const LLM_PROVIDER_REGISTRY: Record<string, LlmProviderRegistryEntry> = {
+  openrouter: {
+    value: 'openrouter',
+    label: 'OpenRouter',
+    defaultModel: 'openai/gpt-4o-mini',
+    suggestedModels: [
+      'openai/gpt-4o-mini',
+      'openai/gpt-4o',
+      'anthropic/claude-3.5-sonnet',
+      'google/gemini-2.5-flash',
+    ],
+    baseURL: 'https://openrouter.ai/api/v1',
+  },
+  openai: {
+    value: 'openai',
+    label: 'OpenAI',
+    defaultModel: 'gpt-4o-mini',
+    suggestedModels: ['gpt-4o-mini', 'gpt-4o'],
+  },
+};

--- a/src/modules/llm-session/dto/llm-provider-models-response.dto.ts
+++ b/src/modules/llm-session/dto/llm-provider-models-response.dto.ts
@@ -11,14 +11,14 @@ export class LlmProviderModelsResponseDto {
 
   @ApiProperty({
     description: 'Default model used by the backend registry',
-    example: 'gpt-4o-mini',
+    example: 'openai/gpt-4o-mini',
   })
   defaultModel: string;
 
   @ApiProperty({
     description:
       'Backend-controlled model suggestions. These are suggestions, not a closed validation list.',
-    example: ['gpt-4o-mini'],
+    example: ['openai/gpt-4o-mini', 'openai/gpt-4o', 'openai/gpt-4.1'],
     isArray: true,
   })
   suggestedModels: string[];

--- a/src/modules/llm-session/dto/llm-provider-models-response.dto.ts
+++ b/src/modules/llm-session/dto/llm-provider-models-response.dto.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import {ApiProperty} from '@nestjs/swagger';
+
+export class LlmProviderModelsResponseDto {
+  @ApiProperty({description: 'Provider identifier', example: 'openai'})
+  provider: string;
+
+  @ApiProperty({
+    description: 'Default model used by the backend registry',
+    example: 'gpt-4o-mini',
+  })
+  defaultModel: string;
+
+  @ApiProperty({
+    description:
+      'Backend-controlled model suggestions. These are suggestions, not a closed validation list.',
+    example: ['gpt-4o-mini'],
+    isArray: true,
+  })
+  suggestedModels: string[];
+}

--- a/src/modules/llm-session/dto/llm-provider-response.dto.ts
+++ b/src/modules/llm-session/dto/llm-provider-response.dto.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import {ApiProperty} from '@nestjs/swagger';
+
+export class LlmProviderResponseDto {
+  @ApiProperty({description: 'Provider identifier', example: 'openai'})
+  value: string;
+
+  @ApiProperty({description: 'Human-readable provider name', example: 'OpenAI'})
+  label: string;
+
+  @ApiProperty({
+    description: 'Default model used by the backend registry',
+    example: 'gpt-4o-mini',
+  })
+  defaultModel: string;
+
+  @ApiProperty({
+    description:
+      'Backend-controlled model suggestions. These are suggestions, not a closed validation list.',
+    example: ['gpt-4o-mini'],
+    isArray: true,
+  })
+  suggestedModels: string[];
+}

--- a/src/modules/llm-session/dto/llm-provider-response.dto.ts
+++ b/src/modules/llm-session/dto/llm-provider-response.dto.ts
@@ -14,14 +14,14 @@ export class LlmProviderResponseDto {
 
   @ApiProperty({
     description: 'Default model used by the backend registry',
-    example: 'gpt-4o-mini',
+    example: 'openai/gpt-4o-mini',
   })
   defaultModel: string;
 
   @ApiProperty({
     description:
       'Backend-controlled model suggestions. These are suggestions, not a closed validation list.',
-    example: ['gpt-4o-mini'],
+    example: ['openai/gpt-4o-mini', 'openai/gpt-4o', 'anthropic/claude-3.7-sonnet'],
     isArray: true,
   })
   suggestedModels: string[];

--- a/src/modules/llm-session/entity/llm-session.entity.ts
+++ b/src/modules/llm-session/entity/llm-session.entity.ts
@@ -6,6 +6,7 @@
 import { Task } from 'src/modules/task/entities/task.entity';
 import { User } from 'src/modules/user/entity/user.entity';
 import {
+  Column,
   Entity,
   ManyToOne,
   OneToMany,
@@ -24,6 +25,9 @@ export class LlmSession {
 
   @ManyToOne(() => Task, (task) => task.llmSessions, { onDelete: 'CASCADE' })
   task: Task;
+
+  @Column({ nullable: true, type: 'text' })
+  systemInstruction?: string | null;
 
   @OneToMany(() => LlmMessage, (msg) => msg.session, { cascade: true })
   messages: LlmMessage[];

--- a/src/modules/llm-session/llm-session.controller.ts
+++ b/src/modules/llm-session/llm-session.controller.ts
@@ -3,8 +3,16 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { Body, Controller, Param, Post, Res, UseGuards } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -14,44 +22,80 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { Response } from 'express';
+import {Response} from 'express';
 
-import { LlmSessionResponseDto } from './dto/llm-session-response.dto';
-import { LlmSessionService } from './llm-session.service';
+import {LlmProviderModelsResponseDto} from './dto/llm-provider-models-response.dto';
+import {LlmProviderResponseDto} from './dto/llm-provider-response.dto';
+import {LlmSessionResponseDto} from './dto/llm-session-response.dto';
+import {LlmSessionService} from './llm-session.service';
 
 @ApiTags('LLM Session')
 @ApiBearerAuth('jwt')
 @UseGuards(AuthGuard('jwt'))
 @Controller('llm-session')
 export class LlmSessionController {
-  constructor(private readonly llmSessionService: LlmSessionService) { }
+  constructor(private readonly llmSessionService: LlmSessionService) {}
+
+  @Get('providers')
+  @ApiOperation({summary: 'List supported LLM providers'})
+  @ApiResponse({
+    status: 200,
+    description: 'Supported providers.',
+    type: LlmProviderResponseDto,
+    isArray: true,
+  })
+  getProviders(): LlmProviderResponseDto[] {
+    return this.llmSessionService.getProviders();
+  }
+
+  @Get('providers/:provider/models')
+  @ApiOperation({summary: 'List suggested models for an LLM provider'})
+  @ApiParam({
+    name: 'provider',
+    type: String,
+    description: 'Provider identifier',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Suggested provider models.',
+    type: LlmProviderModelsResponseDto,
+  })
+  getProviderModels(
+    @Param('provider') provider: string,
+  ): LlmProviderModelsResponseDto {
+    return this.llmSessionService.getProviderModels(provider);
+  }
 
   @Post('start')
-  @ApiOperation({ summary: 'Start an LLM session' })
+  @ApiOperation({summary: 'Start an LLM session'})
   @ApiBody({
     schema: {
       type: 'object',
       properties: {
-        taskId: { type: 'string', description: 'Task ID' },
-        userId: { type: 'string', description: 'User ID' },
+        taskId: {type: 'string', description: 'Task ID'},
+        userId: {type: 'string', description: 'User ID'},
       },
       required: ['taskId', 'userId'],
     },
   })
-  @ApiResponse({ status: 201, description: 'Session started.', type: LlmSessionResponseDto })
-  async startSession(@Body() body: { taskId: string; userId: string }) {
+  @ApiResponse({
+    status: 201,
+    description: 'Session started.',
+    type: LlmSessionResponseDto,
+  })
+  async startSession(@Body() body: {taskId: string; userId: string}) {
     return this.llmSessionService.startSession(body.userId, body.taskId);
   }
 
   @Post(':id/message')
-  @ApiOperation({ summary: 'Send a message to an LLM session' })
-  @ApiParam({ name: 'id', type: String, description: 'LLM session ID' })
+  @ApiOperation({summary: 'Send a message to an LLM session'})
+  @ApiParam({name: 'id', type: String, description: 'LLM session ID'})
   @ApiBody({
     schema: {
       type: 'object',
       properties: {
-        userId: { type: 'string', description: 'User ID' },
-        content: { type: 'string', description: 'Message content' },
+        userId: {type: 'string', description: 'User ID'},
+        content: {type: 'string', description: 'Message content'},
       },
       required: ['userId', 'content'],
     },
@@ -62,19 +106,20 @@ export class LlmSessionController {
     description: 'Streaming response from the model.',
     schema: {
       type: 'string',
-      example: 'This topic can be explored by comparing multiple independent sources...',
+      example:
+        'This topic can be explored by comparing multiple independent sources...',
     },
   })
   async sendMessage(
     @Param('id') sessionId: string,
-    @Body() body: { userId: string; content: string },
+    @Body() body: {userId: string; content: string},
     @Res() res: Response,
   ) {
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
     res.setHeader('Transfer-Encoding', 'chunked');
 
     try {
-      const { stream, saveBotResponse } =
+      const {stream, saveBotResponse} =
         await this.llmSessionService.processChatMessage(
           sessionId,
           body.userId,

--- a/src/modules/llm-session/llm-session.service.spec.ts
+++ b/src/modules/llm-session/llm-session.service.spec.ts
@@ -49,4 +49,27 @@ describe('LlmSessionService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('should hide openrouter from public provider list', () => {
+    const providers = service.getProviders();
+
+    expect(providers.some((provider) => provider.value === 'openrouter')).toBe(
+      false,
+    );
+    expect(providers.some((provider) => provider.value === 'openai')).toBe(
+      true,
+    );
+    expect(providers.some((provider) => provider.value === 'anthropic')).toBe(
+      true,
+    );
+  });
+
+  it('should return provider models for public aliases', () => {
+    expect(service.getProviderModels('google')).toEqual(
+      expect.objectContaining({
+        provider: 'google',
+        defaultModel: 'google/gemini-2.5-flash',
+      }),
+    );
+  });
 });

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -63,6 +63,7 @@ export class LlmSessionService {
             apiKey: true,
             modelProvider: true,
             model: true,
+            systemPrompt: true,
           },
         },
       },
@@ -98,7 +99,17 @@ export class LlmSessionService {
 
     const modelName = providerConfig.model || 'gemini-2.5-flash';
     const genAI = new GoogleGenerativeAI(providerConfig.apiKey);
-    const model = genAI.getGenerativeModel({ model: modelName });
+    const modelConfig: any = {
+      model: modelName,
+    };
+
+    if (providerConfig.systemInstruction) {
+      modelConfig.systemInstruction = {
+        parts: [{ text: providerConfig.systemInstruction }],
+      };
+    }
+
+    const model = genAI.getGenerativeModel(modelConfig);
     const chat = model.startChat({ history: historyForAi });
 
     try {

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -20,7 +20,11 @@ import {Task} from 'src/modules/task/entities/task.entity';
 import {User} from 'src/modules/user/entity/user.entity';
 import {Repository} from 'typeorm';
 
-import {LLM_PROVIDER_REGISTRY} from './constants/llm-provider-registry.constants';
+import {
+  getDisplayProviderValue,
+  getPublicLlmProviderEntries,
+  resolveLlmProvider,
+} from './constants/llm-provider-registry.constants';
 import {LlmMessage} from './entity/llm-message.entity';
 import {LlmSession} from './entity/llm-session.entity';
 
@@ -35,7 +39,7 @@ export class LlmSessionService {
   ) {}
 
   getProviders() {
-    return Object.values(LLM_PROVIDER_REGISTRY).map(
+    return getPublicLlmProviderEntries().map(
       ({value, label, defaultModel, suggestedModels}) => ({
         value,
         label,
@@ -46,12 +50,16 @@ export class LlmSessionService {
   }
 
   getProviderModels(provider: string) {
-    const providerConfig = LLM_PROVIDER_REGISTRY[provider];
-    if (!providerConfig) {
+    const providerConfig = resolveLlmProvider(provider);
+    if (!providerConfig || !providerConfig.public) {
       throw new NotFoundException('LLM provider not found');
     }
     return {
-      provider: providerConfig.value,
+      provider:
+        getDisplayProviderValue(
+          providerConfig.value,
+          providerConfig.defaultModel,
+        ) ?? providerConfig.value,
       defaultModel: providerConfig.defaultModel,
       suggestedModels: providerConfig.suggestedModels,
     };
@@ -115,7 +123,7 @@ export class LlmSessionService {
     });
 
     const providerName = String(providerConfig.modelProvider);
-    const provider = LLM_PROVIDER_REGISTRY[providerName];
+    const provider = resolveLlmProvider(providerName, String(providerConfig.model || ''));
     if (!provider) {
       throw new ForbiddenException('LLM provider not supported');
     }

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -118,9 +118,10 @@ export class LlmSessionService {
 
     const history = await this.llmMessageRepository.find({
       where: {session: {id: sessionId}},
-      order: {createdAt: 'ASC'},
+      order: {createdAt: 'DESC'},
       take: 20,
     });
+    history.reverse();
 
     const providerName = String(providerConfig.modelProvider);
     const provider = resolveLlmProvider(providerName, String(providerConfig.model || ''));
@@ -146,7 +147,7 @@ export class LlmSessionService {
     const model = new ChatOpenAI({
       apiKey: String(providerConfig.apiKey),
       model: String(providerConfig.model || provider.defaultModel),
-      temperature: Number(providerConfig.temperature ?? 0.7),
+      temperature: Number(providerConfig.temperature ?? 0.5),
       streaming: true,
       configuration: baseURL
         ? {

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -3,24 +3,26 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { Content, GoogleGenerativeAI } from '@google/generative-ai';
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
+import {ChatOpenAI} from '@langchain/openai';
 import {
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Task } from 'src/modules/task/entities/task.entity';
-import { User } from 'src/modules/user/entity/user.entity';
-import { Repository } from 'typeorm';
+import {InjectRepository} from '@nestjs/typeorm';
+import {Task} from 'src/modules/task/entities/task.entity';
+import {User} from 'src/modules/user/entity/user.entity';
+import {Repository} from 'typeorm';
 
-import { LlmMessage } from './entity/llm-message.entity';
-import { LlmSession } from './entity/llm-session.entity';
-
-type GoogleModelConfig = {
-  model: string;
-  systemInstruction?: string;
-};
+import {LLM_PROVIDER_REGISTRY} from './constants/llm-provider-registry.constants';
+import {LlmMessage} from './entity/llm-message.entity';
+import {LlmSession} from './entity/llm-session.entity';
 
 @Injectable()
 export class LlmSessionService {
@@ -30,13 +32,36 @@ export class LlmSessionService {
     @InjectRepository(LlmMessage)
     private readonly llmMessageRepository: Repository<LlmMessage>,
     @InjectRepository(Task) private readonly taskRepository: Repository<Task>,
-  ) { }
+  ) {}
+
+  getProviders() {
+    return Object.values(LLM_PROVIDER_REGISTRY).map(
+      ({value, label, defaultModel, suggestedModels}) => ({
+        value,
+        label,
+        defaultModel,
+        suggestedModels,
+      }),
+    );
+  }
+
+  getProviderModels(provider: string) {
+    const providerConfig = LLM_PROVIDER_REGISTRY[provider];
+    if (!providerConfig) {
+      throw new NotFoundException('LLM provider not found');
+    }
+    return {
+      provider: providerConfig.value,
+      defaultModel: providerConfig.defaultModel,
+      suggestedModels: providerConfig.suggestedModels,
+    };
+  }
 
   async startSession(userId: string, taskId: string): Promise<LlmSession> {
     const existingSession = await this.llmSessionRepository.findOne({
-      where: { user: { _id: userId }, task: { _id: taskId } },
+      where: {user: {_id: userId}, task: {_id: taskId}},
       relations: ['messages'],
-      order: { messages: { createdAt: 'ASC' } },
+      order: {messages: {createdAt: 'ASC'}},
     });
 
     if (existingSession) {
@@ -46,14 +71,14 @@ export class LlmSessionService {
     const task = await this.taskRepository
       .createQueryBuilder('task')
       .addSelect('task.provider_config')
-      .where('task._id = :taskId', { taskId })
+      .where('task._id = :taskId', {taskId})
       .getOne();
     if (!task) {
       throw new NotFoundException('Task not found');
     }
 
     const newSession = this.llmSessionRepository.create({
-      user: { _id: userId } as User,
+      user: {_id: userId} as User,
       task: task,
       systemInstruction: task.provider_config?.systemInstruction ?? null,
     });
@@ -67,7 +92,7 @@ export class LlmSessionService {
       .leftJoinAndSelect('session.task', 'task')
       .leftJoinAndSelect('session.user', 'user')
       .addSelect('task.provider_config')
-      .where('session.id = :sessionId', { sessionId })
+      .where('session.id = :sessionId', {sessionId})
       .getOne();
     if (!session) throw new NotFoundException('Session not found');
     if (session.user._id !== userId)
@@ -84,38 +109,50 @@ export class LlmSessionService {
     });
 
     const history = await this.llmMessageRepository.find({
-      where: { session: { id: sessionId } },
-      order: { createdAt: 'ASC' },
+      where: {session: {id: sessionId}},
+      order: {createdAt: 'ASC'},
       take: 20,
     });
 
-    const historyForAi: Content[] = history.slice(0, -1).map((msg) => ({
-      role: msg.role,
-      parts: [{ text: msg.content }],
-    }));
-
-    if (!['google'].includes(providerConfig.modelProvider)) {
+    const providerName = String(providerConfig.modelProvider);
+    const provider = LLM_PROVIDER_REGISTRY[providerName];
+    if (!provider) {
       throw new ForbiddenException('LLM provider not supported');
     }
 
-    const modelName = providerConfig.model || 'gemini-2.5-flash';
-    const genAI = new GoogleGenerativeAI(providerConfig.apiKey);
-    const modelConfig: GoogleModelConfig = {
-      model: modelName,
-    };
-
+    const messages: BaseMessage[] = [];
     if (providerConfig.systemInstruction) {
-      modelConfig.systemInstruction = providerConfig.systemInstruction;
+      messages.push(
+        new SystemMessage(String(providerConfig.systemInstruction)),
+      );
     }
+    messages.push(
+      ...history.map((msg) =>
+        msg.role === 'user'
+          ? new HumanMessage(msg.content)
+          : new AIMessage(msg.content),
+      ),
+    );
 
-    const model = genAI.getGenerativeModel(modelConfig);
-    const chat = model.startChat({ history: historyForAi });
+    const baseURL = providerConfig.baseURL || provider.baseURL;
+    const model = new ChatOpenAI({
+      apiKey: String(providerConfig.apiKey),
+      model: String(providerConfig.model || provider.defaultModel),
+      temperature: Number(providerConfig.temperature ?? 0.7),
+      streaming: true,
+      configuration: baseURL
+        ? {
+            baseURL: String(baseURL),
+            defaultHeaders: provider.defaultHeaders,
+          }
+        : undefined,
+    });
 
     try {
-      const result = await chat.sendMessageStream(content);
+      const stream = await model.stream(messages);
 
       return {
-        stream: result.stream,
+        stream: this.toTextChunkStream(stream),
         saveBotResponse: async (fulltext: string) => {
           await this.llmMessageRepository.save({
             content: fulltext,
@@ -125,18 +162,50 @@ export class LlmSessionService {
         },
       };
     } catch (error) {
-      console.error('Error Gemini:', error);
-      throw new Error('Error processing Gemini AI response', {cause: error});
+      console.error('Error LangChain:', error);
+      throw new Error('Error processing LLM response', {cause: error});
     }
   }
 
-  async findByUserIdAndTaskId(userId: string, taskId: string): Promise<LlmSession> {
+  private async *toTextChunkStream(stream: AsyncIterable<unknown>) {
+    for await (const chunk of stream) {
+      yield {
+        text: () => this.extractTextFromChunk(chunk),
+      };
+    }
+  }
+
+  private extractTextFromChunk(chunk: unknown): string {
+    const content = (chunk as {content?: unknown}).content;
+    if (typeof content === 'string') {
+      return content;
+    }
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === 'string') {
+            return part;
+          }
+          if (part && typeof part === 'object' && 'text' in part) {
+            return String((part as {text: unknown}).text);
+          }
+          return '';
+        })
+        .join('');
+    }
+    return '';
+  }
+
+  async findByUserIdAndTaskId(
+    userId: string,
+    taskId: string,
+  ): Promise<LlmSession> {
     return await this.llmSessionRepository.findOne({
       where: {
-        user: { _id: userId },
-        task: { _id: taskId }
+        user: {_id: userId},
+        task: {_id: taskId},
       },
-      relations: ['messages']
+      relations: ['messages'],
     });
   }
 }

--- a/src/modules/llm-session/llm-session.service.ts
+++ b/src/modules/llm-session/llm-session.service.ts
@@ -17,6 +17,11 @@ import { Repository } from 'typeorm';
 import { LlmMessage } from './entity/llm-message.entity';
 import { LlmSession } from './entity/llm-session.entity';
 
+type GoogleModelConfig = {
+  model: string;
+  systemInstruction?: string;
+};
+
 @Injectable()
 export class LlmSessionService {
   constructor(
@@ -38,7 +43,11 @@ export class LlmSessionService {
       return existingSession;
     }
 
-    const task = await this.taskRepository.findOne({ where: { _id: taskId } });
+    const task = await this.taskRepository
+      .createQueryBuilder('task')
+      .addSelect('task.provider_config')
+      .where('task._id = :taskId', { taskId })
+      .getOne();
     if (!task) {
       throw new NotFoundException('Task not found');
     }
@@ -46,28 +55,20 @@ export class LlmSessionService {
     const newSession = this.llmSessionRepository.create({
       user: { _id: userId } as User,
       task: task,
+      systemInstruction: task.provider_config?.systemInstruction ?? null,
     });
 
     return await this.llmSessionRepository.save(newSession);
   }
 
   async processChatMessage(sessionId: string, userId: string, content: string) {
-    const session = await this.llmSessionRepository.findOne({
-      where: { id: sessionId },
-      relations: ['task', 'user'],
-      select: {
-        id: true,
-        task: {
-          _id: true,
-          provider_config: {
-            apiKey: true,
-            modelProvider: true,
-            model: true,
-            systemPrompt: true,
-          },
-        },
-      },
-    });
+    const session = await this.llmSessionRepository
+      .createQueryBuilder('session')
+      .leftJoinAndSelect('session.task', 'task')
+      .leftJoinAndSelect('session.user', 'user')
+      .addSelect('task.provider_config')
+      .where('session.id = :sessionId', { sessionId })
+      .getOne();
     if (!session) throw new NotFoundException('Session not found');
     if (session.user._id !== userId)
       throw new ForbiddenException('Session does not belong to user');
@@ -99,14 +100,12 @@ export class LlmSessionService {
 
     const modelName = providerConfig.model || 'gemini-2.5-flash';
     const genAI = new GoogleGenerativeAI(providerConfig.apiKey);
-    const modelConfig: any = {
+    const modelConfig: GoogleModelConfig = {
       model: modelName,
     };
 
     if (providerConfig.systemInstruction) {
-      modelConfig.systemInstruction = {
-        parts: [{ text: providerConfig.systemInstruction }],
-      };
+      modelConfig.systemInstruction = providerConfig.systemInstruction;
     }
 
     const model = genAI.getGenerativeModel(modelConfig);

--- a/src/modules/survey/entity/survey.entity.ts
+++ b/src/modules/survey/entity/survey.entity.ts
@@ -7,6 +7,7 @@ import { BaseEntity } from 'src/model/base-entity';
 import { Experiment } from 'src/modules/experiment/entity/experiment.entity';
 import { SurveyAnswer } from 'src/modules/survey-answer/entity/survey-answer.entity';
 import { Task } from 'src/modules/task/entities/task.entity';
+import { TaskSurvey } from 'src/modules/task-survey/entity/taskSurvey.entity';
 import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 
 import { QuestionDTO } from '../dto/question.dto';
@@ -51,4 +52,7 @@ export class Survey extends BaseEntity {
 
   @Column({ default: true })
   required: boolean;
+
+  @OneToMany(() => TaskSurvey, (taskSurvey) => taskSurvey.survey)
+  taskSurveys: TaskSurvey[];
 }

--- a/src/modules/task-survey/entity/taskSurvey.entity.ts
+++ b/src/modules/task-survey/entity/taskSurvey.entity.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import {Survey} from 'src/modules/survey/entity/survey.entity';
+import {Task} from 'src/modules/task/entities/task.entity';
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn, Unique} from 'typeorm';
+
+@Entity()
+@Unique('UQ_task_survey_task_id_survey_id', ['task_id', 'survey_id'])
+export class TaskSurvey {
+  @PrimaryGeneratedColumn('uuid')
+  _id: string;
+
+  @ManyToOne(() => Task, (task) => task.taskSurveys, {onDelete: 'CASCADE'})
+  task: Task;
+  @Column()
+  task_id: string;
+
+  @ManyToOne(() => Survey, (survey) => survey.taskSurveys, {onDelete: 'CASCADE'})
+  survey: Survey;
+  @Column()
+  survey_id: string;
+}

--- a/src/modules/task-survey/task-survey.controller.ts
+++ b/src/modules/task-survey/task-survey.controller.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import {Controller, Delete, Get, HttpCode, Param, Post, UseGuards} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
+import {ApiBearerAuth, ApiOperation, ApiParam, ApiTags} from '@nestjs/swagger';
+
+import {Survey} from '../survey/entity/survey.entity';
+import {TaskSurvey} from './entity/taskSurvey.entity';
+import {TaskSurveyService} from './task-survey.service';
+
+@ApiTags('Task Survey')
+@ApiBearerAuth('jwt')
+@UseGuards(AuthGuard('jwt'))
+@Controller('task-survey')
+export class TaskSurveyController {
+  constructor(private readonly taskSurveyService: TaskSurveyService) {}
+
+  @Post('task/:taskId/survey/:surveyId')
+  @ApiOperation({summary: 'Link a survey to a task'})
+  @ApiParam({name: 'taskId', type: String})
+  @ApiParam({name: 'surveyId', type: String})
+  async link(
+    @Param('taskId') taskId: string,
+    @Param('surveyId') surveyId: string,
+  ): Promise<TaskSurvey> {
+    return await this.taskSurveyService.link(taskId, surveyId);
+  }
+
+  @Delete('task/:taskId/survey/:surveyId')
+  @HttpCode(204)
+  @ApiOperation({summary: 'Unlink a survey from a task'})
+  @ApiParam({name: 'taskId', type: String})
+  @ApiParam({name: 'surveyId', type: String})
+  async unlink(
+    @Param('taskId') taskId: string,
+    @Param('surveyId') surveyId: string,
+  ): Promise<void> {
+    return await this.taskSurveyService.unlink(taskId, surveyId);
+  }
+
+  @Get('task/:taskId')
+  @ApiOperation({summary: 'List surveys linked to a task'})
+  @ApiParam({name: 'taskId', type: String})
+  async findSurveysByTask(@Param('taskId') taskId: string): Promise<Survey[]> {
+    return await this.taskSurveyService.findSurveysByTask(taskId);
+  }
+}

--- a/src/modules/task-survey/task-survey.module.ts
+++ b/src/modules/task-survey/task-survey.module.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import {forwardRef, Module} from '@nestjs/common';
+import {TypeOrmModule} from '@nestjs/typeorm';
+
+import {SurveyModule} from '../survey/survey.module';
+import {TaskModule} from '../task/task.module';
+import {TaskSurvey} from './entity/taskSurvey.entity';
+import {TaskSurveyController} from './task-survey.controller';
+import {TaskSurveyService} from './task-survey.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([TaskSurvey]),
+    forwardRef(() => TaskModule),
+    forwardRef(() => SurveyModule),
+  ],
+  providers: [TaskSurveyService],
+  controllers: [TaskSurveyController],
+  exports: [TaskSurveyService],
+})
+export class TaskSurveyModule {}

--- a/src/modules/task-survey/task-survey.service.ts
+++ b/src/modules/task-survey/task-survey.service.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import {
+  ConflictException,
+  forwardRef,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {InjectRepository} from '@nestjs/typeorm';
+import {Repository} from 'typeorm';
+
+import {SurveyService} from '../survey/survey.service';
+import {Survey} from '../survey/entity/survey.entity';
+import {TaskService} from '../task/task.service';
+import {TaskSurvey} from './entity/taskSurvey.entity';
+
+@Injectable()
+export class TaskSurveyService {
+  constructor(
+    @InjectRepository(TaskSurvey)
+    private readonly taskSurveyRepository: Repository<TaskSurvey>,
+    @Inject(forwardRef(() => TaskService))
+    private readonly taskService: TaskService,
+    @Inject(forwardRef(() => SurveyService))
+    private readonly surveyService: SurveyService,
+  ) {}
+
+  async link(taskId: string, surveyId: string): Promise<TaskSurvey> {
+    const task = await this.taskService.findOne(taskId);
+    if (!task) {
+      throw new NotFoundException('Task não encontrada.');
+    }
+    const survey = await this.surveyService.findOne(surveyId);
+    if (!survey) {
+      throw new NotFoundException('Survey não encontrado.');
+    }
+    const existing = await this.taskSurveyRepository.findOne({
+      where: {task_id: taskId, survey_id: surveyId},
+    });
+    if (existing) {
+      throw new ConflictException('Survey já está vinculado a esta task.');
+    }
+    return await this.taskSurveyRepository.save({task, survey});
+  }
+
+  async unlink(taskId: string, surveyId: string): Promise<void> {
+    const record = await this.taskSurveyRepository.findOne({
+      where: {task_id: taskId, survey_id: surveyId},
+    });
+    if (!record) {
+      throw new NotFoundException('Vínculo entre task e survey não encontrado.');
+    }
+    await this.taskSurveyRepository.delete({_id: record._id});
+  }
+
+  async findSurveysByTask(taskId: string): Promise<Survey[]> {
+    const records = await this.taskSurveyRepository.find({
+      where: {task_id: taskId},
+      relations: ['survey'],
+    });
+    return records.map((r) => r.survey);
+  }
+
+  async findTasksBySurvey(surveyId: string): Promise<string[]> {
+    const records = await this.taskSurveyRepository.find({
+      where: {survey_id: surveyId},
+    });
+    return records.map((r) => r.task_id);
+  }
+}

--- a/src/modules/task/dto/create-task.dto.ts
+++ b/src/modules/task/dto/create-task.dto.ts
@@ -98,7 +98,7 @@ export class CreateTaskDto {
     example: {
       model: 'openai/gpt-4o-mini',
       apiKey: 'sk-or-v1-...',
-      modelProvider: 'openrouter',
+      modelProvider: 'openai',
     },
     required: false,
   })

--- a/src/modules/task/dto/create-task.dto.ts
+++ b/src/modules/task/dto/create-task.dto.ts
@@ -3,59 +3,105 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+import {ApiProperty} from '@nestjs/swagger';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class CreateTaskDto {
-  @ApiProperty({ description: 'Task title', example: 'Find evidence of confirmation bias' })
+  @ApiProperty({
+    description: 'Task title',
+    example: 'Find evidence of confirmation bias',
+  })
   @IsNotEmpty()
   @IsString()
   title: string;
 
-  @ApiProperty({ description: 'Short summary for display', example: 'Search and evaluate sources' })
+  @ApiProperty({
+    description: 'Short summary for display',
+    example: 'Search and evaluate sources',
+  })
   @IsNotEmpty()
   @IsString()
   summary: string;
 
-  @ApiProperty({ description: 'Full task description', example: 'Search for articles and summarize findings.' })
+  @ApiProperty({
+    description: 'Full task description',
+    example: 'Search for articles and summarize findings.',
+  })
   @IsOptional()
   @IsString()
   description: string;
 
-  @ApiProperty({ description: 'Search source identifier', example: 'bing' })
+  @ApiProperty({description: 'Search source identifier', example: 'bing'})
   @IsOptional()
   @IsString()
   search_source: string;
 
-  @ApiProperty({ description: 'Experiment ID this task belongs to', example: '64d2f4a8e5f9b20b1c8a9f10' })
+  @ApiProperty({
+    description: 'Experiment ID this task belongs to',
+    example: '64d2f4a8e5f9b20b1c8a9f10',
+  })
   @IsNotEmpty()
   @IsString()
   experiment_id: string;
 
-  @ApiProperty({ description: 'Survey ID associated with this task', example: '64d2f4a8e5f9b20b1c8a9f11', required: false })
+  @ApiProperty({
+    description: 'Survey ID associated with this task',
+    example: '64d2f4a8e5f9b20b1c8a9f11',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   survey_id?: string;
 
-  @ApiProperty({ description: 'Rule type used for task selection', example: 'score', required: false })
+  @ApiProperty({
+    description: 'Rule type used for task selection',
+    example: 'score',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   rule_type?: string;
 
-  @ApiProperty({ description: 'Question IDs used by rule selection', example: ['64d2f4a8e5f9b20b1c8a9f21'], required: false })
+  @ApiProperty({
+    description: 'Question IDs used by rule selection',
+    example: ['64d2f4a8e5f9b20b1c8a9f21'],
+    required: false,
+  })
   @IsOptional()
   @IsArray()
   questionsId?: string[];
 
-  @ApiProperty({ description: 'Minimum score to qualify', example: 10, required: false })
+  @ApiProperty({
+    description: 'Minimum score to qualify',
+    example: 10,
+    required: false,
+  })
   @IsOptional()
   min_score?: number;
 
-  @ApiProperty({ description: 'Maximum score to qualify', example: 25, required: false })
+  @ApiProperty({
+    description: 'Maximum score to qualify',
+    example: 25,
+    required: false,
+  })
   @IsOptional()
   max_score?: number;
 
-  @ApiProperty({ description: 'Provider specific configuration', example: {"model":"gemini-2.5-flash","apiKey":"asdasdasdsadd","modelProvider":"google"}, required: false })
+  @ApiProperty({
+    description: 'Provider specific configuration',
+    example: {
+      model: 'openai/gpt-4o-mini',
+      apiKey: 'sk-or-v1-...',
+      modelProvider: 'openrouter',
+    },
+    required: false,
+  })
   @IsOptional()
   @IsObject()
   provider_config?: Record<string, unknown>;

--- a/src/modules/task/dto/task-response.dto.ts
+++ b/src/modules/task/dto/task-response.dto.ts
@@ -72,7 +72,7 @@ export class TaskResponseDto {
     example: {
       model: 'openai/gpt-4o-mini',
       apiKey: 'sk-o-----v1-1234',
-      modelProvider: 'openrouter',
+      modelProvider: 'openai',
       systemInstruction: 'You are a friendly and helpful assistant.',
     },
     required: false,

--- a/src/modules/task/dto/task-response.dto.ts
+++ b/src/modules/task/dto/task-response.dto.ts
@@ -3,51 +3,101 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { ApiProperty } from '@nestjs/swagger';
+import {ApiProperty} from '@nestjs/swagger';
 
 export class TaskResponseDto {
-  @ApiProperty({ description: 'Task ID', example: '9f0d7a5d-2a11-4b6b-8c1a-3f7a4a0292f9' })
+  @ApiProperty({
+    description: 'Task ID',
+    example: '9f0d7a5d-2a11-4b6b-8c1a-3f7a4a0292f9',
+  })
   _id: string;
 
-  @ApiProperty({ description: 'Task title', example: 'Find evidence of confirmation bias' })
+  @ApiProperty({
+    description: 'Task title',
+    example: 'Find evidence of confirmation bias',
+  })
   title: string;
 
-  @ApiProperty({ description: 'Short summary for display', example: 'Search and evaluate sources' })
+  @ApiProperty({
+    description: 'Short summary for display',
+    example: 'Search and evaluate sources',
+  })
   summary: string;
 
-  @ApiProperty({ description: 'Task description', example: 'Search for articles and summarize findings.' })
+  @ApiProperty({
+    description: 'Task description',
+    example: 'Search for articles and summarize findings.',
+  })
   description: string;
 
-  @ApiProperty({ description: 'Search source identifier', example: 'bing' })
+  @ApiProperty({description: 'Search source identifier', example: 'bing'})
   search_source: string;
 
-  @ApiProperty({ description: 'Experiment ID associated with this task', example: '64d2f4a8e5f9b20b1c8a9f10' })
+  @ApiProperty({
+    description: 'Experiment ID associated with this task',
+    example: '64d2f4a8e5f9b20b1c8a9f10',
+  })
   experiment_id: string;
 
-  @ApiProperty({ description: 'Survey ID associated with this task', example: '64d2f4a8e5f9b20b1c8a9f11', required: false })
+  @ApiProperty({
+    description: 'Survey ID associated with this task',
+    example: '64d2f4a8e5f9b20b1c8a9f11',
+    required: false,
+  })
   survey_id?: string;
 
-  @ApiProperty({ description: 'Rule type used for task selection', example: 'score', required: false })
+  @ApiProperty({
+    description: 'Rule type used for task selection',
+    example: 'score',
+    required: false,
+  })
   rule_type?: string;
 
-  @ApiProperty({ description: 'Minimum score to qualify', example: 10, required: false })
+  @ApiProperty({
+    description: 'Minimum score to qualify',
+    example: 10,
+    required: false,
+  })
   min_score?: number;
 
-  @ApiProperty({ description: 'Maximum score to qualify', example: 25, required: false })
+  @ApiProperty({
+    description: 'Maximum score to qualify',
+    example: 25,
+    required: false,
+  })
   max_score?: number;
 
-  @ApiProperty({ description: 'Provider configuration returned by API', example: {"model":"gemini-2.5-flash","apiKey":"asda-----sdsadd","modelProvider":"google","systemInstruction":"You are a friendly and helpful assistant."}, required: false })
+  @ApiProperty({
+    description: 'Provider configuration returned by API',
+    example: {
+      model: 'openai/gpt-4o-mini',
+      apiKey: 'sk-o-----v1-1234',
+      modelProvider: 'openrouter',
+      systemInstruction: 'You are a friendly and helpful assistant.',
+    },
+    required: false,
+  })
   provider_config?: Record<string, unknown>;
 
-  @ApiProperty({ description: 'Whether secret fields in provider config were masked', example: true, required: false })
+  @ApiProperty({
+    description: 'Whether secret fields in provider config were masked',
+    example: true,
+    required: false,
+  })
   provider_config_masked?: boolean;
 
-  @ApiProperty({ description: 'Whether the record is active', example: true })
+  @ApiProperty({description: 'Whether the record is active', example: true})
   isActive: boolean;
 
-  @ApiProperty({ description: 'Creation timestamp', example: '2026-02-24T13:30:00.000Z' })
+  @ApiProperty({
+    description: 'Creation timestamp',
+    example: '2026-02-24T13:30:00.000Z',
+  })
   createdAt: Date;
 
-  @ApiProperty({ description: 'Last update timestamp', example: '2026-02-24T13:30:00.000Z' })
+  @ApiProperty({
+    description: 'Last update timestamp',
+    example: '2026-02-24T13:30:00.000Z',
+  })
   lastChangeAt: Date;
 }

--- a/src/modules/task/dto/task-response.dto.ts
+++ b/src/modules/task/dto/task-response.dto.ts
@@ -36,7 +36,7 @@ export class TaskResponseDto {
   @ApiProperty({ description: 'Maximum score to qualify', example: 25, required: false })
   max_score?: number;
 
-  @ApiProperty({ description: 'Provider configuration returned by API', example: {"model":"gemini-2.5-flash","apiKey":"asda-----sdsadd","modelProvider":"google"}, required: false })
+  @ApiProperty({ description: 'Provider configuration returned by API', example: {"model":"gemini-2.5-flash","apiKey":"asda-----sdsadd","modelProvider":"google","systemInstruction":"You are a friendly and helpful assistant."}, required: false })
   provider_config?: Record<string, unknown>;
 
   @ApiProperty({ description: 'Whether secret fields in provider config were masked', example: true, required: false })

--- a/src/modules/task/entities/task.entity.ts
+++ b/src/modules/task/entities/task.entity.ts
@@ -3,20 +3,21 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { BaseEntity } from 'src/model/base-entity';
-import { Experiment } from 'src/modules/experiment/entity/experiment.entity';
-import { LlmSession } from 'src/modules/llm-session/entity/llm-session.entity';
-import { Survey } from 'src/modules/survey/entity/survey.entity';
-import { TaskQuestionMap } from 'src/modules/task-question-map/entity/taskQuestionMap.entity';
-import { UserTask } from 'src/modules/user-task/entities/user-tasks.entity';
-import { UserTaskSession } from 'src/modules/user-task-session/entities/user-task-session.entity';
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import {BaseEntity} from 'src/model/base-entity';
+import {Experiment} from 'src/modules/experiment/entity/experiment.entity';
+import {LlmSession} from 'src/modules/llm-session/entity/llm-session.entity';
+import {Survey} from 'src/modules/survey/entity/survey.entity';
+import {TaskQuestionMap} from 'src/modules/task-question-map/entity/taskQuestionMap.entity';
+import {UserTask} from 'src/modules/user-task/entities/user-tasks.entity';
+import {UserTaskSession} from 'src/modules/user-task-session/entities/user-task-session.entity';
+import {Column, Entity, ManyToOne, OneToMany} from 'typeorm';
 
 export type TaskProviderConfig = {
   modelProvider?: string;
   searchProvider?: string;
   model?: string;
   apiKey?: string;
+  baseURL?: string;
   cx?: string;
   systemInstruction?: string;
   [key: string]: unknown;
@@ -56,7 +57,7 @@ export class Task extends BaseEntity {
     onDelete: 'CASCADE',
   })
   survey: Survey;
-  @Column({ nullable: true })
+  @Column({nullable: true})
   survey_id: string;
 
   @OneToMany(() => TaskQuestionMap, (taskQuestionMap) => taskQuestionMap.task, {
@@ -64,15 +65,15 @@ export class Task extends BaseEntity {
   })
   taskQuestionsMap: TaskQuestionMap[];
 
-  @Column({ nullable: true })
+  @Column({nullable: true})
   rule_type: string;
 
-  @Column({ nullable: true })
+  @Column({nullable: true})
   max_score: number;
-  @Column({ nullable: true })
+  @Column({nullable: true})
   min_score: number;
 
-  @OneToMany(() => UserTask, (userTask) => userTask.task, { cascade: true })
+  @OneToMany(() => UserTask, (userTask) => userTask.task, {cascade: true})
   userTasks: UserTask[];
 
   @OneToMany(() => UserTaskSession, (session) => session.task)

--- a/src/modules/task/entities/task.entity.ts
+++ b/src/modules/task/entities/task.entity.ts
@@ -18,6 +18,7 @@ export type TaskProviderConfig = {
   model?: string;
   apiKey?: string;
   cx?: string;
+  systemInstruction?: string;
   [key: string]: unknown;
 };
 

--- a/src/modules/task/entities/task.entity.ts
+++ b/src/modules/task/entities/task.entity.ts
@@ -8,6 +8,7 @@ import {Experiment} from 'src/modules/experiment/entity/experiment.entity';
 import {LlmSession} from 'src/modules/llm-session/entity/llm-session.entity';
 import {Survey} from 'src/modules/survey/entity/survey.entity';
 import {TaskQuestionMap} from 'src/modules/task-question-map/entity/taskQuestionMap.entity';
+import {TaskSurvey} from 'src/modules/task-survey/entity/taskSurvey.entity';
 import {UserTask} from 'src/modules/user-task/entities/user-tasks.entity';
 import {UserTaskSession} from 'src/modules/user-task-session/entities/user-task-session.entity';
 import {Column, Entity, ManyToOne, OneToMany} from 'typeorm';
@@ -78,4 +79,7 @@ export class Task extends BaseEntity {
 
   @OneToMany(() => UserTaskSession, (session) => session.task)
   sessions: UserTaskSession[];
+
+  @OneToMany(() => TaskSurvey, (taskSurvey) => taskSurvey.task, {cascade: true})
+  taskSurveys: TaskSurvey[];
 }

--- a/src/modules/task/task.module.ts
+++ b/src/modules/task/task.module.ts
@@ -9,6 +9,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ExperimentModule } from '../experiment/experiment.module';
 import { SurveyModule } from '../survey/survey.module';
 import { TaskQuestionMapModule } from '../task-question-map/task-question-map.module';
+import { TaskSurveyModule } from '../task-survey/task-survey.module';
 import { Task } from './entities/task.entity';
 import { TaskController } from './task.controller';
 import { TaskService } from './task.service';
@@ -19,6 +20,7 @@ import { TaskService } from './task.service';
     forwardRef(() => ExperimentModule),
     forwardRef(() => SurveyModule),
     forwardRef(() => TaskQuestionMapModule),
+    forwardRef(() => TaskSurveyModule),
   ],
   providers: [TaskService],
   controllers: [TaskController],

--- a/src/modules/task/task.service.spec.ts
+++ b/src/modules/task/task.service.spec.ts
@@ -15,20 +15,29 @@ import { TaskService } from './task.service';
 
 describe('TaskService', () => {
   let service: TaskService;
+  let taskRepository: {
+    find: jest.Mock;
+    findOne: jest.Mock;
+    save: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
 
   beforeEach(async () => {
+    taskRepository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TaskService,
         {
           provide: getRepositoryToken(Task),
-          useValue: {
-            find: jest.fn(),
-            findOne: jest.fn(),
-            save: jest.fn(),
-            update: jest.fn(),
-            delete: jest.fn(),
-          },
+          useValue: taskRepository,
         },
         {
           provide: ExperimentService,
@@ -56,5 +65,26 @@ describe('TaskService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should expose provider alias instead of openrouter in task output', () => {
+    const result = (service as unknown as {
+      applyProviderConfigMask: (task: Task) => unknown;
+    }).applyProviderConfigMask({
+      provider_config: {
+        modelProvider: 'openrouter',
+        model: 'openai/gpt-4o-mini',
+        apiKey: 'secret-key',
+      },
+    } as Task);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        provider_config: expect.objectContaining({
+          modelProvider: 'openai',
+          model: 'openai/gpt-4o-mini',
+        }),
+      }),
+    );
   });
 });

--- a/src/modules/task/task.service.ts
+++ b/src/modules/task/task.service.ts
@@ -15,6 +15,7 @@ import { In, Repository } from 'typeorm';
 import { ExperimentService } from '../experiment/experiment.service';
 import { SurveyService } from '../survey/survey.service';
 import { TaskQuestionMapService } from '../task-question-map/task-question-map.service';
+import { TaskSurveyService } from '../task-survey/task-survey.service';
 import { getDisplayProviderValue } from '../llm-session/constants/llm-provider-registry.constants';
 import { PROVIDER_CONFIG_SECRET_KEYS } from './constants/provider-config.constants';
 import { CreateTaskDto } from './dto/create-task.dto';
@@ -37,6 +38,8 @@ export class TaskService {
     private readonly surveyService: SurveyService,
     @Inject(forwardRef(() => TaskQuestionMapService))
     private readonly taskQuestionMapService: TaskQuestionMapService,
+    @Inject(forwardRef(() => TaskSurveyService))
+    private readonly taskSurveyService: TaskSurveyService,
   ) { }
 
   private normalizeProviderConfigForOutput(
@@ -175,6 +178,11 @@ export class TaskService {
   }
 
   async update(id: string, updateTaskDto: UpdateTaskDto): Promise<TaskWithProviderMask> {
+    const dto = updateTaskDto as any;
+    const hasLinkedSurveyRefs = 'linkedSurveyRefs' in dto;
+    const linkedSurveyRefs: string[] = dto.linkedSurveyRefs ?? [];
+    delete dto.linkedSurveyRefs;
+
     const oldTask = await this.findOne(id);
     if (
       updateTaskDto.survey_id &&
@@ -194,6 +202,21 @@ export class TaskService {
       );
     }
     delete updateTaskDto.questionsId;
+
+    if (hasLinkedSurveyRefs) {
+      const currentSurveys = await this.taskSurveyService.findSurveysByTask(id);
+      const currentIds = new Set(currentSurveys.map((s) => s._id));
+      const newIds = new Set([...new Set(linkedSurveyRefs)]);
+
+      await Promise.all([
+        ...[...newIds].filter((ref) => !currentIds.has(ref)).map((ref) =>
+          this.taskSurveyService.link(id, ref).catch(() => null),
+        ),
+        ...[...currentIds].filter((ref) => !newIds.has(ref)).map((ref) =>
+          this.taskSurveyService.unlink(id, ref).catch(() => null),
+        ),
+      ]);
+    }
 
     if (updateTaskDto.provider_config) {
       const current = await this.taskRepository.findOne({

--- a/src/modules/task/task.service.ts
+++ b/src/modules/task/task.service.ts
@@ -15,6 +15,7 @@ import { In, Repository } from 'typeorm';
 import { ExperimentService } from '../experiment/experiment.service';
 import { SurveyService } from '../survey/survey.service';
 import { TaskQuestionMapService } from '../task-question-map/task-question-map.service';
+import { getDisplayProviderValue } from '../llm-session/constants/llm-provider-registry.constants';
 import { PROVIDER_CONFIG_SECRET_KEYS } from './constants/provider-config.constants';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
@@ -37,6 +38,31 @@ export class TaskService {
     @Inject(forwardRef(() => TaskQuestionMapService))
     private readonly taskQuestionMapService: TaskQuestionMapService,
   ) { }
+
+  private normalizeProviderConfigForOutput(
+    providerConfig?: TaskProviderConfig,
+  ): TaskProviderConfig | undefined {
+    if (!providerConfig) {
+      return undefined;
+    }
+
+    const displayProvider = getDisplayProviderValue(
+      typeof providerConfig.modelProvider === 'string'
+        ? providerConfig.modelProvider
+        : undefined,
+      typeof providerConfig.model === 'string' ? providerConfig.model : undefined,
+    );
+
+    if (!displayProvider) {
+      return providerConfig;
+    }
+
+    return {
+      ...providerConfig,
+      modelProvider: displayProvider,
+    };
+  }
+
   private applyProviderConfigMask(task: Task | null): TaskWithProviderMask | null {
     if (!task) {
       return task;
@@ -46,7 +72,9 @@ export class TaskService {
     );
     return {
       ...task,
-      provider_config: sanitized as Record<string, unknown>,
+      provider_config: this.normalizeProviderConfigForOutput(
+        sanitized as TaskProviderConfig,
+      ) as Record<string, unknown>,
       provider_config_masked: masked,
     } as TaskWithProviderMask;
   }

--- a/src/modules/user-task/dto/task-execution-details.dto.ts
+++ b/src/modules/user-task/dto/task-execution-details.dto.ts
@@ -59,6 +59,8 @@ export class LlmMessageDetailsDto {
 }
 
 export class LlmTaskDetailsDto {
+  @ApiProperty({ nullable: true, required: false, description: 'System instruction configured for the LLM task' })
+  systemInstruction?: string | null;
 
   @ApiProperty({ type: [LlmMessageDetailsDto], description: 'Messages exchanged with the model' })
   messages: LlmMessageDetailsDto[];

--- a/src/modules/user-task/user-task.service.ts
+++ b/src/modules/user-task/user-task.service.ts
@@ -245,12 +245,23 @@ export class UserTaskService {
   ): Promise<UserTask[]> {
     const userTasks = await this.userTaskRepository.find({
       where: { user_id: userId },
-      relations: ['task'],
+      relations: ['task', 'task.taskSurveys'],
     });
     const userTaskByExperiment = userTasks.filter(
       (userTask) => userTask.task.experiment_id === experimentId,
     );
-    return userTaskByExperiment;
+    return userTaskByExperiment.map((ut) => {
+      const {taskSurveys, ...taskRest} = ut.task as any;
+      const surveyIds: string[] = (taskSurveys ?? []).map((ts: any) => ts.survey_id);
+      return {
+        ...ut,
+        task: {
+          ...taskRest,
+          // undefined when no linked surveys → frontend shows all surveys (backward compat)
+          ...(surveyIds.length > 0 && {linkedSurveyRefs: surveyIds}),
+        },
+      };
+    }) as unknown as UserTask[];
   }
 
   async findUsersByTaskId(taskId: string): Promise<User[]> {

--- a/src/modules/user-task/user-task.service.ts
+++ b/src/modules/user-task/user-task.service.ts
@@ -8,7 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { LlmSessionService } from 'src/modules/llm-session/llm-session.service';
 import { In, Repository } from 'typeorm';
 
-import { Task } from '../task/entities/task.entity';
+import { Task, type TaskProviderConfig } from '../task/entities/task.entity';
 import { TaskService } from '../task/task.service';
 import { TaskQuestionMapService } from '../task-question-map/task-question-map.service';
 import { User } from '../user/entity/user.entity';
@@ -384,11 +384,26 @@ export class UserTaskService {
     return tasks.length;
   }
 
+  private getSystemInstruction(
+    sessionSystemInstruction: string | null | undefined,
+    task: Task,
+  ): string | null {
+    return (
+      sessionSystemInstruction ??
+      (task.provider_config as TaskProviderConfig | undefined)
+        ?.systemInstruction ??
+      null
+    );
+  }
+
   async getExecutionDetails(userTaskId: string): Promise<TaskExecutionDetailsDto> {
-    const userTask = await this.userTaskRepository.findOne({
-      where: { _id: userTaskId },
-      relations: ['task', 'user']
-    });
+    const userTask = await this.userTaskRepository
+      .createQueryBuilder('userTask')
+      .leftJoinAndSelect('userTask.task', 'task')
+      .leftJoinAndSelect('userTask.user', 'user')
+      .addSelect('task.provider_config')
+      .where('userTask._id = :userTaskId', { userTaskId })
+      .getOne();
 
     if (!userTask) {
       throw new NotFoundException('UserTask not found');
@@ -457,6 +472,10 @@ export class UserTaskService {
 
       const messages = llmSession ? llmSession.messages : [];
       details.llmDetails = {
+        systemInstruction: this.getSystemInstruction(
+          llmSession?.systemInstruction,
+          task,
+        ),
         messages: messages.map(m => ({
           content: m.content,
           role: m.role,
@@ -471,14 +490,13 @@ export class UserTaskService {
   }
 
   async findByExperimentId(experimentId: string): Promise<UserTask[]> {
-    return await this.userTaskRepository.find({
-      relations: ['task', 'user'],
-      where: {
-        task: {
-          experiment_id: experimentId
-        }
-      }
-    });
+    return await this.userTaskRepository
+      .createQueryBuilder('userTask')
+      .leftJoinAndSelect('userTask.task', 'task')
+      .leftJoinAndSelect('userTask.user', 'user')
+      .addSelect('task.provider_config')
+      .where('task.experiment_id = :experimentId', { experimentId })
+      .getMany();
   }
 
   async getExecutionDetailsFromEntity(userTask: UserTask): Promise<TaskExecutionDetailsDto> {
@@ -545,6 +563,10 @@ export class UserTaskService {
 
       const messages = llmSession ? llmSession.messages : [];
       details.llmDetails = {
+        systemInstruction: this.getSystemInstruction(
+          llmSession?.systemInstruction,
+          task,
+        ),
         messages: messages.map(m => ({
           content: m.content,
           role: m.role,
@@ -559,12 +581,13 @@ export class UserTaskService {
   }
 
   async findByUserAndTask(userId: string, taskId: string): Promise<UserTask[]> {
-    return await this.userTaskRepository.find({
-      relations: ['task', 'user'],
-      where: {
-        user: { _id: userId },
-        task: { _id: taskId }
-      }
-    });
+    return await this.userTaskRepository
+      .createQueryBuilder('userTask')
+      .leftJoinAndSelect('userTask.task', 'task')
+      .leftJoinAndSelect('userTask.user', 'user')
+      .addSelect('task.provider_config')
+      .where('user._id = :userId', { userId })
+      .andWhere('task._id = :taskId', { taskId })
+      .getMany();
   }
 }


### PR DESCRIPTION
 ## Summary

  - Implement task-survey linking module with full CRUD operations, allowing surveys to be associated with specific tasks during
  experiment creation
  - Add LLM provider registry with configurable providers and models per task, including response DTOs and controller endpoints
  - Add system instruction support in model configuration, LLM session and task execution (closes #13)
 
## Fixes
  - Fetch last 20 chat history messages in chronological order (was fetching the first 20)
  - Reduce default LLM temperature from 0.7 to 0.5
  -  Move `axios` from devDependencies to dependencies
  -  Exclude `.env` files from Docker build context

## Notes

> Commits `ad7f136` and `4d60257` have duplicate messages — both
touch experiment creation.